### PR TITLE
Updating repository URL to fix "Edit this page" links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,14 +19,14 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Bitcoin Design
-email: hi@bitcoindesign.com
+email: hi@bitcoindesign.org
 description: "Bitcoin Design aims to be a free open-source community resource that will help designers and developers working on bitcoin-products to create better experiences, faster."
 # baseurl: "Guide" # Only for gh-pages. Comment this line to run the website on localhost:4000
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 
-github_repository_url: "https://github.com/pedromvpg/bitcoin-design-guide/"
+github_repository_url: "https://github.com/BitcoinDesign/Guide/"
 
 # Build settings
 theme: minima
@@ -46,7 +46,7 @@ defaults:
       type: "pages"
     values:
       permalink: ":path/:basename"
-      image: "https://pedromvpg.github.io/bitcoin-design-guide/assets/bitcoin-design-og.png"
+      image: "https://bitcoindesign.github.io/Guide/assets/bitcoin-design-og.png"
 
 
 twitter:

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Bitcoin Design
-email: hi@bitcoindesign.org
+email: no-reply@bitcoindesign.org
 description: "Bitcoin Design aims to be a free open-source community resource that will help designers and developers working on bitcoin-products to create better experiences, faster."
 # baseurl: "Guide" # Only for gh-pages. Comment this line to run the website on localhost:4000
 url: "" # the base hostname & protocol for your site, e.g. http://example.com

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
     </a>
 
     <div class="edit-license">
-      <a class="-edit" target="_blank" href="{{site.github_repository_url}}/blob/gh-pages/{{page.path}}">Edit this page</a>
+      <a class="-edit" target="_blank" href="{{site.github_repository_url}}blob/master/{{page.path}}">Edit this page</a>
 
       <a class="-license" href="{{ "/LICENSE" }}">License</a>
     </div>


### PR DESCRIPTION
The "Edit this page" links currently lead to 404 pages on Github. This update fixes them. Two areas were touched for this. For one, the repository URL in  the config file was updated to point to this repo (instead of Pedros repo). Second, the edit page links in the footer were updated to point to the `main` branch instead of the `gh-pages` branch.

I also changed the email in the config.yml from the `bitcoindesign.com` domain (which we don't have) to `bitcoindesign.org`. Not sure if anyone will ever try to email us there, but at some point we might want to decide officially what to use.

Also updated another reference to Pedros repo to this repo, this one for the website preview image.