### PR TITLE
WIP: feat: build and deploy in workflow

### DIFF
--- a/.github/workflows/guide-builder.yaml
+++ b/.github/workflows/guide-builder.yaml
@@ -1,0 +1,36 @@
+name: guide-builder
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get repo
+        uses: actions/checkout@v2
+        with:
+          ref: 'gh-pages'
+          fetch-depth: 0
+      - name: Merge latest
+        run: |
+          git config user.email "${GITHUB_ACTOR}"
+          git config user.name "${GITHUB_ACTOR}@users.noreply.github.com"
+          git merge --squash origin/dev
+          git push --all -f https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git
+      - name: Install all of the things
+        run: sudo script/bootstrap
+      - name: Build latest website
+        run: script/build
+      - name: Commit new build
+        run: |
+          git config user.email "${GITHUB_ACTOR}"
+          git config user.name "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add _site
+          last_commit=$(git log -1 --format=%s)
+          git commit -m "ci: deploy $last_commit"
+          git push --all -f https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bitcoin Design Guide
 
+![guide-builder](https://github.com/johnsBeharry/bitcoin-design-guide/workflows/guide-builder/badge.svg)
+
 This is a project overview of a design guide for bitcoin with early thoughts on what it could end up being.
 
 Like a travel guide, it provides an introduction to a “foreign place”, shows you the highlights and tells you some of the best stories. It provides facts and maps to figure out how to get around, ideas for tours and things to do. Whether you end up taking the official museum tour, clubbing all night or go on shopping sprees is still your choice. Note that these are guides, not mandates. Just like in a foreign city, you can choose to go off the path, and forge a new direction. Others may just follow in the future.

--- a/script/build
+++ b/script/build
@@ -2,5 +2,5 @@
 
 set -e
 
-echo "Building the example site..."
-bundle exec jekyll build
+echo "Building the site..."
+bundle exec jekyll build -d _site


### PR DESCRIPTION
### Problem
Github pages has 2 modes, static html or jekyll. We use automatic jekyll building in github pages and:
1. the jekyll building is done on github pages on every push to master currently
2. since github pages does the deployment, we have limited access to plugins

how might we have more flexibility over build and deployment of the site while still using github pages?

### Solution
Build the jekyll site in a docker container using github workflows so we have access to all plugins, the output will be html so this can be served by github pages.

### Result
- [x] setup a gh-pages branch to serve website
- [ ] merge changes
- [x] build site with image compression
- [ ] commit as user who triggered the workflow
- [ ] restrict branch access
- [ ] restrict merge to master

Once complete, this gives us the foundations to:
1. build and run code in other languages
2. ...
3. profit

Closes #60 
