### PR TITLE
Style improvements to tables and footnotes and some other updates

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -1,4 +1,3 @@
-
 article.guide {
   position: relative;
 
@@ -168,6 +167,31 @@ article.guide {
       margin-bottom: 0;
       float: right;
       margin-left: 30px;
+    }
+  }
+}
+
+.footnotes {
+  padding: 30px;
+  font-size: 0.8rem;
+  margin: 60px;
+  border: 1px solid #f2f2f2;
+  box-sizing: border-box;
+  &::before {
+    content: "REFERENCES";
+    display: block;
+    margin-bottom: 10px;
+    color: var(--frontHex);
+    letter-spacing: 1px;
+  }
+  ol {
+    margin: 0;
+    list-style-position: inside;
+    li {
+      margin-left: 0;
+      p {
+        display: inline;
+      }
     }
   }
 }

--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -175,7 +175,7 @@ article.guide {
   padding: 30px;
   font-size: 0.8rem;
   margin: 60px 0 0;
-  border: 1px solid #f2f2f2;
+  border: 1px solid rgba(var(--front), 0.05);
   box-sizing: border-box;
   background: #FDFDFD;
   &::before {

--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -174,9 +174,10 @@ article.guide {
 .footnotes {
   padding: 30px;
   font-size: 0.8rem;
-  margin: 60px;
+  margin: 60px 0 0;
   border: 1px solid #f2f2f2;
   box-sizing: border-box;
+  background: #FDFDFD;
   &::before {
     content: "REFERENCES";
     display: block;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -320,3 +320,19 @@ table {
             -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 }
+
+a.footnote {
+  color: #474747;
+  padding: 0 6px;
+  font-size: 0.7rem;
+}
+
+ul.task-list {
+  list-style: none inside;
+  li {
+    margin-left: 0!important;
+      input {
+        margin: 0 1rem 0 0;
+      }
+  }
+}

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -56,6 +56,8 @@ ul, ol, dl, figure,
 hr {
   margin-top: $spacing-unit;
   margin-bottom: $spacing-unit;
+  border: 1px solid rgba(var(--front), 0.05);
+  border-width: 1px 0 0;
 }
 
 /**
@@ -299,17 +301,14 @@ table {
   text-align: $table-text-align;
   color: $table-text-color;
   border-collapse: collapse;
-  border: 1px solid $table-border-color;
-  tr {
-    &:nth-child(even) {
-      background-color: $table-zebra-color;
-    }
-  }
   th, td {
-    padding: ($spacing-unit / 3) ($spacing-unit / 2);
+    padding: ($spacing-unit / 3) 0;
   }
   th {
     border-bottom: 1px solid $table-border-color;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    font-weight: 700;
   }
   td {
     border-bottom: 1px solid $table-border-color;

--- a/js/themes.js
+++ b/js/themes.js
@@ -136,9 +136,12 @@ docReady(function() {
         applyNextTheme();
     });
 
-    document.getElementById('home-banner-info-next').addEventListener('click', function(event) {
-        event.preventDefault();
+    var bannerNext = document.getElementById('home-banner-info-next');
+    if(bannerNext) {
+        bannerNext.addEventListener('click', function(event) {
+            event.preventDefault();
 
-        applyNextTheme();
-    });
+            applyNextTheme();
+        });
+    }
 });

--- a/style.md
+++ b/style.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: guide
 title: Style
 nav_order: 99
 footer_nav: true
@@ -11,7 +11,7 @@ Text can be **bold**, _italic_, or ~~strikethrough~~.
 
 There should be whitespace between paragraphs.
 
-There should be whitespace between paragraphs. We recommend including a README, or a file with information about your project.
+There should be whitespace between paragraphs. We recommend including a README, or a file with information about your project[^1].
 
 # [](#header-1)Header 1
 
@@ -148,3 +148,5 @@ Long, single-line code blocks should not wrap. They should horizontally scroll i
 ```
 The final element.
 ```
+
+[^1]: https://bitcoin.design "Footnote with a caption"


### PR DESCRIPTION
### Problem
1. "Uncaught TypeError: Cannot read property 'addEventListener' of null"
2. table displays a bit weird see below 
3. footnote looks like dangling links or part of the content

#### Table has weird borders
<img width="1248" alt="Screenshot 2020-12-11 at 00 17 10" src="https://user-images.githubusercontent.com/183140/101841577-7add3900-3b46-11eb-8104-629c25a5f57e.png">

### Solution
- fix(theme): check if banner exists before event listener
- style(article): distinguish footnote from content
- style: stretch and reduce styling of table

### Result

#### Table
<img width="848" alt="Screenshot 2020-12-11 at 00 12 27" src="https://user-images.githubusercontent.com/183140/101841218-d1964300-3b45-11eb-92ae-b44c4691674a.png">

#### Footnote
<img width="462" alt="Screenshot 2020-12-11 at 00 11 52" src="https://user-images.githubusercontent.com/183140/101841176-bcb9af80-3b45-11eb-8657-f53dd15f034e.png">

<img width="870" alt="Screenshot 2020-12-11 at 00 13 33" src="https://user-images.githubusercontent.com/183140/101841315-f985a680-3b45-11eb-9811-04ac2faafd4b.png">
