### PR TITLE
fix: offset heading anchors to compensate for nav

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -184,6 +184,21 @@ article.guide {
       margin-left: 30px;
     }
   }
+
+  // fix: add offset for in page links
+  h1[id]::before, h2[id]::before, h3[id]::before,
+  h4[id]::before, h5[id]::before, h6[id]::before {
+    content: '';
+    display: block;
+    position: relative;
+    width: 0;
+    height: 2em;
+    margin-top: -2em;
+    @include media-query(medium-up) {
+      height: 3em;
+      margin-top: -3em;
+    }
+  }
 }
 
 .footnotes {


### PR DESCRIPTION
### Problem

```gherkin
Given the site has a fixed header
When I click on a named anchor link 
And the page scrolls to the heading
Then the heading is out of view because the header is blocking
```
![anchor-offset-problem](https://user-images.githubusercontent.com/183140/102278317-e437c000-3f29-11eb-9aad-59e5373fb929.gif)


### Solution
- Add an offset to the heading
### Result

![anchor-offset-solution](https://user-images.githubusercontent.com/183140/102278333-eb5ece00-3f29-11eb-8564-dc23ee70976d.gif)