### PR TITLE
Modify gemfile and fix deployment fail on Ubuntu

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :jekyll_plugins do
   gem "jekyll-seo-tag"
   gem 'jekyll-compress-images', :git => 'https://github.com/valerijaspasojevic/jekyll-compress-images.git'
   gem 'html-proofer'
+  gem'nokogiri', '1.10.10'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -30,3 +31,4 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :jekyll_plugins do
   gem "jekyll-seo-tag"
   gem 'jekyll-compress-images', :git => 'https://github.com/valerijaspasojevic/jekyll-compress-images.git'
   gem 'html-proofer'
-  gem'nokogiri', '1.10.10'
+  gem 'nokogiri', '1.10.10'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -31,4 +31,3 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,9 @@ GEM
     image_optim_pack (0.7.0)
       fspath (>= 2.1, < 4)
       image_optim (~> 0.19)
+    image_optim_pack (0.7.0-x86_64-linux)
+      fspath (>= 2.1, < 4)
+      image_optim (~> 0.19)
     image_size (2.1.0)
     in_threads (1.5.4)
     jekyll (4.1.1)
@@ -109,6 +112,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   html-proofer
@@ -117,9 +121,10 @@ DEPENDENCIES
   jekyll-feed (~> 0.12)
   jekyll-seo-tag
   minima (~> 2.5)
+  nokogiri (= 1.10.10)
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
 
 BUNDLED WITH
-   2.1.4
+   2.2.2


### PR DESCRIPTION
When trying to build on Ubuntu 20.04 so I began troubleshooting and during that process I faced following issue:

```
An error occurred while installing nokogiri (1.10.10), and Bundler
cannot continue.
Make sure that `gem install nokogiri -v '1.10.10' --source
'https://rubygems.org/'` succeeds before bundling.
```
I modified the gemfile by adding `nokogiri` in extensions and after running `bundle update nokogiri` and `bundle install` I was able to deploy the website.

Gemfile was automatically modified to be better suited for Linux enviroment.

This  is not my field of expertiese, I was just dogfooding, so please try to test this PR on different OS prior to merging.
