### PR TITLE
Fixes header spacing trick to prevent blocking of other elements

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -184,21 +184,6 @@ article.guide {
       margin-left: 30px;
     }
   }
-
-  // fix: add offset for in page links
-  h1[id]::before, h2[id]::before, h3[id]::before,
-  h4[id]::before, h5[id]::before, h6[id]::before {
-    content: '';
-    display: block;
-    position: relative;
-    width: 0;
-    height: 2em;
-    margin-top: -2em;
-    @include media-query(medium-up) {
-      height: 3em;
-      margin-top: -3em;
-    }
-  }
 }
 
 .footnotes {

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -176,11 +176,25 @@ article.guide h1 {
 
 .post-content,
 article.guide {
-  // margin-top: $spacing-unit;
+  h1, h2, h3 {
+    margin-top: 0;
+    padding-top: $spacing-unit * 1;
 
-  h1:not(:first-child), h2, h3 { margin-top: $spacing-unit * 2 }
+    @include media-query(medium-up) {
+      margin-top: 0;
+      padding-top: $spacing-unit * 2;
+    }
+  }
 
-  h4, h5, h6 { margin-top: $spacing-unit }
+  h4, h5, h6 {
+    margin-top: 0;
+    padding-top: $spacing-unit * 0.5;
+
+    @include media-query(medium-up) {
+      margin-top: 0;
+      padding-top: $spacing-unit * 2;
+    }
+  }
 
   h2 {
     @include relative-font-size(1.75);


### PR DESCRIPTION
The author info on the home page banner is currently not clickable because an invisible spacer element is on top of it. This was added for extra spacing when deep-linking to sections, so section headers are not covered by the static nav bar.

This fix replaces the invisible spacer elements with simple top padding. The deep-link spacing is not as nice, but still works. At some point soon we need to get back to these typographic details.

Feel free to suggest a better fix.

Pinging @johnsBeharry 