### PR TITLE
Centralizes Slack invite URL to a config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a project overview of a design guide for bitcoin with early thoughts on 
 
 Like a travel guide, it provides an introduction to a “foreign place”, shows you the highlights and tells you some of the best stories. It provides facts and maps to figure out how to get around, ideas for tours and things to do. Whether you end up taking the official museum tour, clubbing all night or go on shopping sprees is still your choice. Note that these are guides, not mandates. Just like in a foreign city, you can choose to go off the path, and forge a new direction. Others may just follow in the future.
 
-Discussion and collaboration is taking place in the [bitcoin design Slack](https://bitcoindesign.slack.com/join/shared_invite/zt-gytq2snl-4TEWJOTKrXRCB4YLBoDunA#/) (#bitcoin-design-guide).
+Discussion and collaboration is taking place in the [bitcoin design Slack](http://bitcoindesigners.org) (#bitcoin-design-guide).
 
 
 ## Table of Contents
@@ -21,7 +21,7 @@ Discussion and collaboration is taking place in the [bitcoin design Slack](https
 
 The Bitcoin Design Guide is a free open-source community resource that helps designers, developers and others working on non-custodial bitcoin-products to create better experiences, faster. We hope that, over time, it will cover all relevant types of products, including consumer wallets, merchant interactions, exchanges and more. Better products and experiences should ultimately make it more appealing for anyone to own and use bitcoin.
 
-An equally important goal is that this process nurtures an open-source bitcoin design community that can carry this, and other projects forward longer term. The [bitcoin design Slack](https://bitcoindesign.slack.com/join/shared_invite/zt-gytq2snl-4TEWJOTKrXRCB4YLBoDunA#/) mentioned above, and created after the first version of this doc, is the first step in this direction.
+An equally important goal is that this process nurtures an open-source bitcoin design community that can carry this, and other projects forward longer term. The [bitcoin design Slack](http://bitcoindesigners.org) mentioned above, and created after the first version of this doc, is the first step in this direction.
 
 
 ## Process
@@ -34,7 +34,7 @@ The goal is for the process of creating the guide to be as open and decentralize
 
 **DONE** Learn about the main UX issues that need tackling, what a guide could help with, and thoughts about how to foster a long term community. Via early conversations and feedback on this doc.
 
-**DONE** Facilitate communication amongst bitcoin designers by creating a [forum](https://bitcoindesign.slack.com/join/shared_invite/zt-gytq2snl-4TEWJOTKrXRCB4YLBoDunA#/).
+**DONE** Facilitate communication amongst bitcoin designers by creating a [forum](http://bitcoindesigners.org).
 
 **DONE** Start regular video calls. (First call held 9am PT July 1, information on past and upcoming calls can be found [here]( https://github.com/BitcoinDesign/Meta/issues).
 

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ twitter_username: jekyllrb
 github_username:  jekyll
 
 github_repository_url: "https://github.com/BitcoinDesign/Guide/"
+slack_invite_url: "http://bitcoindesigners.org"
 
 # Build settings
 theme: minima

--- a/_includes/home-banner.html
+++ b/_includes/home-banner.html
@@ -9,7 +9,7 @@
       </h1>
       <p>Open-source design for bitcoin products.</p>
       <div class="home-banner-buttons-wrapper">
-        <a id="link-button-1" href="https://bitcoindesign.slack.com/" rel="me">Join us on Slack</a>
+        <a id="link-button-1" href="{{ site.slack_invite_url }}" rel="me">Join us on Slack</a>
         <a id="link-button-2" href="https://github.com/bitcoindesign" target="blank" rel="me">Contribute on Github</a>
       </div>
     </div>
@@ -19,7 +19,7 @@
 </section>
 <section class="home-banner-info">
   <div class="home-banner-info-wrapper">
-    <p>Header design by <a id="home-banner-info-author" href="https://bitcoindesign.slack.com/" target="blank">Blah</p>
+    <p>Header design by <a id="home-banner-info-author" href="{{ site.slack_invite_url }}" target="blank">Blah</p>
     <div class="home-banner-info-options">
       <a href="{{ "/submit-header-design" | relative_url }}" target="blank">Submit your own</a>
       <button id="home-banner-info-next">Next</button>

--- a/contribute.md
+++ b/contribute.md
@@ -33,7 +33,7 @@ If you are not familiar with the concepts of open design, we have a [great intro
 
 ## How to get involved in the community
 
-1. [Join the community on Slack](https://join.slack.com/t/bitcoindesign/shared_invite/zt-gytq2snl-4TEWJOTKrXRCB4YLBoDunA) and say hi in the [#introductions](https://bitcoindesign.slack.com/archives/C0162PV1810) channnel
+1. [Join the community on Slack]({{ site.slack_invite_url }}) and say hi in the [#introductions](https://bitcoindesign.slack.com/archives/C0162PV1810) channnel
 1. [Subscribe to the newsletter](https://bitcoindesign.substack.com) to stay up-to-date
 1. Read up on our [project life cycle](https://github.com/BitcoinDesign/Meta/blob/master/Projects.md)
 1. Browse [issues](https://github.com/BitcoinDesign/Meta/issues) for upcoming calls and discussions around processes and coordination


### PR DESCRIPTION
Somebody on Twitter could not signup up for Slack because the link on the home page lead to the Slack login page instead of the invite page. We have a couple of different Slack links in the codebase spread across multiple pages. With this update, I am centralizing them to a single config variable for easier maintenance and better consistency.

Instead of Slack invite links, it uses the bitcoindesigners.org domain now, so we can update the link in one place without having to touch the codebase.