### PR TITLE
Revise the "Contribute to guide" section landing page

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -49,6 +49,7 @@ If you are not familiar with the concepts of open design, we have a [great intro
 ## Bitcoin Design Guide
 
 - [View the guide]({{ 'guide' | relative_url }})
+- We have a whole section on [how to contribute]({{ 'guide/contribute/' | relative_url }})
 - Follow progress on the [project board](https://github.com/BitcoinDesign/Guide/projects/1)
 - Discuss on the [#bitcoin-design-guide](https://bitcoindesign.slack.com/archives/C015856BDME) Slack channel
 - Review code and content on the [github repository](https://github.com/BitcoinDesign/Guide)

--- a/guide/contribute/contribute.md
+++ b/guide/contribute/contribute.md
@@ -10,9 +10,9 @@ image: /assets/images/guide/contribute/contribute-preview.jpg
 
 # Contribute to the Guide
 
-People around the internet build and shape the Bitcoin Design Guide every day. You can be the part of our open community too!
+People from around the internet build and shape the Bitcoin Design Guide every day. You are invited to join our open community and help us improve these resources!
 
-This page shows you how to get involved and start contributing.
+This section shows you how to get involved and start contributing.
 
 ---
 
@@ -25,26 +25,31 @@ We use the #bitcoin-design-guide channel in the [Bitcoin Design Slack community]
 **[GitHub](https://github.com/BitcoinDesign/Guide)**
 
 We use Github to host the content of the guide. [Issues](https://github.com/BitcoinDesign/Guide/issues) are used to post ideas for improvements, and proposed changes are posted as [Pull Requests](https://github.com/BitcoinDesign/Guide/pulls).
-For some ideas we use [Discussions](https://github.com/BitcoinDesign/Guide/discussions).
+For questions and ideas we use [Discussions](https://github.com/BitcoinDesign/Guide/discussions).
 
 ---
 
-**[Create your first pull request]({{ '/guide/contribute/propose-a-change/' | relative_url }})**
+**[Proposing changes]({{ '/guide/contribute/propose-a-change/' | relative_url }})**
 
-Learn the basics of GitHub, an open-source collaboration platform and create your first pull request.
+Learn the basics of GitHub, an open-source collaboration platform, and propose a change by creating your first pull request.
 
 ---
 
 **[Become a reviewer]({{ '/guide/contribute/review/' | relative_url }})**
 
-Get involved in the reviewing process. It's a fantastic entry-point for new contributors.
-
+Get involved in the review process. It's a fantastic entry-point for new contributors and essential for improving the quality and usefulness of the guide.
 
 ---
 
 **[Content guidelines]({{ '/guide/contribute/content-guidelines/' | relative_url }})**
 
-Tips on how to write for the guide, with the goal of achieving a consistent tone across all pages.
+Tips on how to write for the guide. The goal is to achieve a consistent tone across all pages for the benefit of readers.
+
+---
+
+**[Illustration guidelines]({{ '/guide/contribute/illustration-guidelines/' | relative_url }})**
+
+Notes on how to prepare visuals for use in the guide. We encourage diverse creative expressions, so this page focuses mostly on basics like file names and image sizes.
 
 ---
 
@@ -54,4 +59,4 @@ Layout and formatting options available for content pages, from headers and bloc
 
 ---
 
-These contribution guidelines are for the Bitcoin Design Guide project. To get involved with the broader Bitcoin Design community and projects, check out [general contribution guidelines](https://bitcoin.design/contribute/).
+These contribution guidelines are for the Bitcoin Design Guide project. To get involved with the broader Bitcoin Design community and projects, check out [general contribution guidelines]({{ '/contribute/' | relative_url }}).


### PR DESCRIPTION
For issue #150. 

Added a link to the "Illustration guidelines" page.
Minor copy revisions.
Linking to this section from our /contribute page.