### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig configuration for BitcoinDesign/Guide
+# https://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file, utf-8 charset
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space


### PR DESCRIPTION
This PR adds an [EditorConfig](https://editorconfig.org) config file which might consolidates whitespace usage eventually across the project:

* remove trailing whitespace
* insert final new-line
* end-of-line is LF
* charset is UTF-8

I didn't change any files afterall, because this would lead to lots of merge conflicts. But if contributors' editor supports this, they will create consistent files.