### PR TITLE
Adds the guide landing page to the secondary nav as "Introduction"

### DIFF
--- a/_includes/secondary-nav.html
+++ b/_includes/secondary-nav.html
@@ -28,7 +28,7 @@
           {%- if node.has_children -%}
             <button class="nav-list-expander" aria-expanded="false" aria-controls="nav-list-{{ forloop.index }}" title="Toggle list"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></button>
           {%- endif -%}
-          <a href="{{ node.url | absolute_url }}" class="nav-list-link{% if page.url == node.url %} -active{% endif %}">{{ node.title }}</a>
+          <a href="{{ node.url | absolute_url }}" class="nav-list-link{% if page.url == node.url %} -active{% endif %}">{%- if node.secondary_nav_title -%}{{ node.secondary_nav_title }}{%- else -%}{{ node.title }}{%- endif -%}</a>
           {%- if node.has_children -%}
             {%- assign children_list = pages_list | where: "parent", node.title -%}
             <ul class="nav-list" id="nav-list-{{ forloop.index }}">

--- a/guide.md
+++ b/guide.md
@@ -2,10 +2,11 @@
 layout: guide
 nav_order: 1
 title: Guide
+secondary_nav_title: Introduction
 description: The Bitcoin Design Guide is a reference for the design of bitcoin applications. 
 permalink: /guide/
 main_nav: true
-secondary_nav: false
+secondary_nav: true
 main_classes: -no-top-padding
 image: /assets/images/guide/bitcoin-island-preview.jpg
 ---

--- a/guide/case-studies/introduction.md
+++ b/guide/case-studies/introduction.md
@@ -2,7 +2,7 @@
 layout: guide
 title: Case studies
 description: A range of case study designs for Bitcoin applications.
-nav_order: 5
+nav_order: 7
 has_children: true
 permalink: /guide/case-studies/
 main_classes: -no-top-padding

--- a/guide/foundations/foundations.md
+++ b/guide/foundations/foundations.md
@@ -2,7 +2,7 @@
 layout: guide
 title: Foundations
 description: Basics for designing great Bitcoin products.
-nav_order: 5
+nav_order: 6
 has_children: true
 permalink: /guide/foundations/
 image: /assets/images/guide/foundations/foundations-preview.jpg

--- a/guide/getting-started/getting-started.md
+++ b/guide/getting-started/getting-started.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Getting started
-nav_order: 1
+nav_order: 2
 has_children: true
 permalink: /guide/getting-started/introduction/
 main_classes: -no-top-padding

--- a/guide/glossary.md
+++ b/guide/glossary.md
@@ -2,7 +2,7 @@
 layout: guide
 title: Glossary
 permalink: /guide/glossary/
-nav_order: 6
+nav_order: 8
 main_classes: -no-top-padding
 image: /assets/images/guide/glossary/glossary-preview.jpg
 ---

--- a/guide/onboarding/introduction.md
+++ b/guide/onboarding/introduction.md
@@ -2,7 +2,7 @@
 layout: guide
 title: Onboarding
 description: An overview of some of the concepts to consider when building onboarding experiences.
-nav_order: 2
+nav_order: 3
 permalink: /guide/onboarding/introduction/
 main_classes: -no-top-padding
 image: /assets/images/guide/onboarding/onboarding.png

--- a/guide/payments/introduction.md
+++ b/guide/payments/introduction.md
@@ -2,7 +2,7 @@
 layout: guide
 title: Payments
 description: Diving into the user experience of moving Bitcoin
-nav_order: 4
+nav_order: 5
 has_children: false
 permalink: /guide/payments/
 main_classes: -no-top-padding

--- a/guide/private-key-management/introduction.md
+++ b/guide/private-key-management/introduction.md
@@ -2,7 +2,7 @@
 layout: guide
 title: Private key management
 description: An overview of private key management schemes, including descriptions of  available approaches, some advice and best practices.
-nav_order: 3
+nav_order: 4
 has_children: true
 permalink: /guide/private-key-management/introduction/
 main_classes: -no-top-padding


### PR DESCRIPTION
Per this [Slack convo](https://bitcoindesign.slack.com/archives/C015856BDME/p1615028281023000).

The guide landing page is currently not in the secondary navigation that is used to browse the guide, so that page page becomes easy to miss. This PR addresses the issue.