### PR TITLE
Test for fixing canonical URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title: Bitcoin Design
 email: no-reply@bitcoindesign.org
 description: "Bitcoin Design aims to be a free open-source community resource that will help designers and developers working on bitcoin-products to create better experiences, faster."
 # baseurl: "Guide" # Only for gh-pages. Comment this line to run the website on localhost:4000
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://bitcoin.design" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 

--- a/index.md
+++ b/index.md
@@ -3,6 +3,7 @@
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 
 layout: home
+permalink: /
 ---
 
 ## We are helping make [bitcoin](https://bitcoin.org) more intuitive and accessible.
@@ -18,4 +19,4 @@ Everyone is welcome to join and participate.
 
 Our first community project, the [Bitcoin Design Guide]({{ '/guide' | relative_url }}) is a free, open-source repository for anyone building non-custodial bitcoin products. The guide will eventually cover consumer wallets, merchant interactions, financial applications, and much more.
 
-If you’d like to help by providing feedback, submitting ideas, or creating content, check out the list of current [issues](https://github.com/BitcoinDesign/Guide/issues) or join us on Slack. 
+If you’d like to help by providing feedback, submitting ideas, or creating content, check out the list of current [issues](https://github.com/BitcoinDesign/Guide/issues) or join us on Slack.


### PR DESCRIPTION
Jekyll creates relative URLs for the canonical tags in the website meta data. These need to be absolute based for search engines. This fixes the issue by updating the config. Just need to test that this doesn't break any other URL generation across the site.

Tests cannot happen on localhost as URLs are treated differently on the local dev environment.