### PR TITLE
Fixes anchor tag in the image include

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -1,13 +1,13 @@
 <figure{% if include.layout %} class="-{{ include.layout }}"{% endif %}>
-	<a href="{{ include.link-url }}">
+	{% if include.link-url %}<a href="{{ include.link-url }}">{% endif %}
         <img
-        	src="{{ include.image | relative_url }}" 
+        	src="{{ include.image | relative_url }}"
         	{% if include.retina %} srcset="{{ include.image | relative_url }} 1x, {{ include.retina | relative_url }} 2x"{% endif %}
-        	alt="{{ include.alt-text }}" 
-        	width="{{ include.width }}" 
+        	alt="{{ include.alt-text }}"
+        	width="{{ include.width }}"
         	height="{{ include.height }}"
         	loading="lazy"
     	>
-    </a>
+    {% if include.link-url %}</a>{% endif %}
     {% if include.caption %}<figcaption markdown="1">{{ include.caption | markdownify }}</figcaption>{% endif %}
 </figure>


### PR DESCRIPTION
Images rendered via the image include are all links, even when they don't have a link assigned. Clicking them takes you back up the page. To fix this bug, I added an if statement in the image include to only render the anchor tag when needed.