### PR TITLE
Additional style options for the image component

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -5,6 +5,20 @@ article.guide {
     margin-top: 0;
   }
 
+  figure {
+    &.-background {
+      padding: 20px;
+      background-color: #f8f8f8;
+    }
+
+    &.-shadow {
+      img {
+        box-shadow: 0px 5px 15px rgba(#404040, 0.07);
+        border-radius: 10px;
+      }
+    }
+  }
+
   a.button {
     display: inline-block;
     padding: 0 20px;


### PR DESCRIPTION
Extends the "class" property of the image component with 2 additional styling options. "background" adds padding and a background color, while "shadow" rounds the contained image and adds a drop shadow.

Usage example:

```
{% include image.html
   image = "/assets/images/guide/contribute/formatting/example-image-square.jpg"
   retina = "/assets/images/guide/contribute/formatting/example-image-square@2x.jpg"
   alt-text = "Example image"
   width = 400
   height = 400
   layout = "float-left-desktop -background -shadow"
   caption="This image has a background, drop shadow, as well as handsomely rounded corners."
%}
```

![image 14](https://user-images.githubusercontent.com/695901/114419879-1abdd880-9bb4-11eb-80cb-a146df68a21c.png)
