### PR TITLE
Fixes missing first character of blockquotes

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -195,10 +195,6 @@ blockquote {
 
   > :last-child {
     margin-bottom: 0;
-
-    &::first-letter {
-      font-size: 0;
-    }
   }
 
   i, em {


### PR DESCRIPTION
Caused by CSS from the original Jekyll theme we started with that was not removed.