### PR TITLE
Fixes layout issue for long text in the image slide gallery component

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -523,15 +523,15 @@ article.guide {
     max-width: none !important;
 
     figure {
-      img {
-        box-shadow: 0 20px 10px -8px rgba(black, 0.05);
-        border: 1px solid rgba(black, 0.1);
-      }
-
       margin-top: 0;
       margin-bottom: 0;
       float: left;
       margin-right: 30px;
+
+      img {
+        box-shadow: 0 20px 10px -8px rgba(black, 0.05);
+        border: 1px solid rgba(black, 0.1);
+      }
     }
 
     @include media-query(small) {
@@ -570,9 +570,10 @@ article.guide {
       flex-shrink: 0;
       margin-top: 0;
       margin-bottom: 0;
+      width: min-content;
 
       img {
-        width: 100%;
+        max-width: none;
         height: auto;
       }
 

--- a/guide/contribute/formatting.md
+++ b/guide/contribute/formatting.md
@@ -270,7 +270,7 @@ A horizontal slide show of images. When the content is too wide for the screen, 
    image = "/assets/images/guide/contribute/formatting/example-image-mobile-screen.png"
    retina = "/assets/images/guide/contribute/formatting/example-image-mobile-screen@2x.png"
    alt-text = "Example image"
-   caption = "Example text"
+   caption = "Sed in lacus vitae turpis lobortis ultrices. Aenean hendrerit nec elit in sagittis. Nulla mi ante, luctus vitae tincidunt ut, rhoncus ac ex. Morbi sit amet mauris est."
    width = 250
    height = 541
 %}


### PR DESCRIPTION
The text didn't wrap and so the images resized to the text width and got huge.