### PR TITLE
Self-custody typo

### DIFF
--- a/guide/getting-started/personal-finance.md
+++ b/guide/getting-started/personal-finance.md
@@ -203,7 +203,7 @@ For example, [Glacier Protocol](https://glacierprotocol.org){:target="_blank"} i
    height = 800
 %}
 
-Many people don’t personally custody their long-term savings. They rely on banks and financial service providers to provide security and help manage and invest those savings. Savings accounts and related products may also incentivize customers with low-interest rates that may or may not be high enough to keep up with inflation.
+Many people don’t self-cusody their long-term savings. They rely on banks and financial service providers to provide security and help manage and invest those savings. Savings accounts and related products may also incentivize customers with low-interest rates that may or may not be high enough to keep up with inflation.
 
 ## Investing
 


### PR DESCRIPTION
Based on [Daniel's suggestion](https://github.com/BitcoinDesign/Guide/issues/202#issuecomment-821097725) of changing all cases on non-custody to self-custody I went over the guide to make this change. This was the only instance found on the current master branch. For those writing copy currently for the guide it would be good to make this change on current work before pushing PRs.