### PR TITLE
Replace box-shadow with drop-shadow filter

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -13,7 +13,7 @@ article.guide {
 
     &.-shadow {
       img {
-        box-shadow: 0px 5px 15px rgba(#404040, 0.07);
+        filter: drop-shadow(0px 5px 15px rgba(#000000, 0.07));
         border-radius: 10px;
       }
     }


### PR DESCRIPTION
box-shadow applies to the containing HTML element, which is always a rectangular div. The drop-shadow filter applies to the content of the image, including any transparent areas, creating more realistic shadows on images (like custom border radii). Necessary to change, because the default border-radius applied by the shadow class does not actually match how we're exporting PNGs.

Small fix that primarily affects the new pages in onboarding and payments that embed wallet UI kit images.