### PR TITLE
Remove case studies from pkm introduction page

### DIFF
--- a/guide/private-key-management/introduction.md
+++ b/guide/private-key-management/introduction.md
@@ -55,10 +55,4 @@ An introduction to some of the common private key management schemes for shared 
 
 ---
 
-### [Case studies]({{ '/guide/case-studies/' | relative_url }})
-
-A look at hypothetical application uses and suitable approaches to private key management for each of them.
-
----
-
 Start at the top with [private key schemes]({{ '/guide/private-key-management/schemes/' | relative_url }}).

--- a/guide/private-key-management/schemes.md
+++ b/guide/private-key-management/schemes.md
@@ -35,7 +35,7 @@ Important aspects to consider when choosing a private key management scheme is w
 
 
 * **Target audience** - Are your users completely new to bitcoin and its concepts, or well versed in all the technological underpinnings?
-* **Use case** - Are you building a product for daily payments, or a long-term life-saving storage solution?
+* **Use case** - Are you building a [personal finance]({{ '/guide/getting-started/personal-finance/' | relative_url }}) product for daily payments, or a long-term life-saving storage solution?
 * **Value stored** - While we always strive for no loss of funds, how critical to their financial situation would it be if your user lost access to their funds?
 
 


### PR DESCRIPTION
Two fixes spotted in the holistic review #202 

- Case studies removed from Private Key introduction page (content was moved out a while ago, but this got left behind)
- Link to personal finance from a relevant place on the schemes overview page