### PR TITLE
PKM - Rename Recovery phrase page

### DIFF
--- a/guide/private-key-management/cloud-backup.md
+++ b/guide/private-key-management/cloud-backup.md
@@ -83,4 +83,4 @@ This makes the backup accessible by the user on a new device, should they lose t
 
 ---
 
-Next, let's look at [Recovery phrase]({{ '/guide/private-key-management/recovery-phrase/' | relative_url }}).
+Next, let's look at [manual backup of recovery phrase]({{ '/guide/private-key-management/recovery-phrase/' | relative_url }}).

--- a/guide/private-key-management/cloud-backup.md
+++ b/guide/private-key-management/cloud-backup.md
@@ -83,4 +83,4 @@ This makes the backup accessible by the user on a new device, should they lose t
 
 ---
 
-Next, let's look at [Recovery phrase]({{ '/guide/private-key-management/manual-backup/' | relative_url }}).
+Next, let's look at [Recovery phrase]({{ '/guide/private-key-management/recovery-phrase/' | relative_url }}).

--- a/guide/private-key-management/cloud-backup.md
+++ b/guide/private-key-management/cloud-backup.md
@@ -83,4 +83,4 @@ This makes the backup accessible by the user on a new device, should they lose t
 
 ---
 
-Next, let's look at [manual backups]({{ '/guide/private-key-management/manual-backup/' | relative_url }}).
+Next, let's look at [Recovery phrase]({{ '/guide/private-key-management/manual-backup/' | relative_url }}).

--- a/guide/private-key-management/introduction.md
+++ b/guide/private-key-management/introduction.md
@@ -49,7 +49,7 @@ A single key is stored locally on the device. No user action is required for bac
 
 ---
 
-### [Recovery phrase]({{ '/guide/private-key-management/manual-backup/' | relative_url }})
+### [Recovery phrase]({{ '/guide/private-key-management/recovery-phrase/' | relative_url }})
 
 A single key is stored locally on the device. User action is required for backup with a recovery phrase.
 

--- a/guide/private-key-management/introduction.md
+++ b/guide/private-key-management/introduction.md
@@ -49,7 +49,7 @@ A single key is stored locally on the device. No user action is required for bac
 
 ---
 
-### [Manual backup]({{ '/guide/private-key-management/manual-backup/' | relative_url }})
+### [Recovery phrase]({{ '/guide/private-key-management/manual-backup/' | relative_url }})
 
 A single key is stored locally on the device. User action is required for backup with a recovery phrase.
 

--- a/guide/private-key-management/introduction.md
+++ b/guide/private-key-management/introduction.md
@@ -49,7 +49,7 @@ A single key is stored locally on the device. No user action is required for bac
 
 ---
 
-### [Recovery phrase]({{ '/guide/private-key-management/recovery-phrase/' | relative_url }})
+### [Manual backup of recovery phrase]({{ '/guide/private-key-management/recovery-phrase/' | relative_url }})
 
 A single key is stored locally on the device. User action is required for backup with a recovery phrase.
 

--- a/guide/private-key-management/manual-backup.md
+++ b/guide/private-key-management/manual-backup.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Manual backup
+title: Recovery phrase
 description: An overview of personal private key management schemes.
 nav_order: 3
 parent: Private key management
@@ -16,9 +16,9 @@ Descriptions of schemes suitable for a single user.
 
 -->
 
-# Manual backup / Recovery phrase
+# Recovery phrase
 
-Manual backup of the [recovery phrase]({{ '/guide/glossary/#recovery-phrase' | relative_url }}) has been the most common private key management scheme by far since its proposal with [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) in 2013. If you have used any [non-custodial]({{ '/guide/glossary/#non-custodial--custodial-wallet' | relative_url }}) bitcoin application you are likely to have experienced the onboarding requirements of manual backups.
+A [recovery phrase]({{ '/guide/glossary/#recovery-phrase' | relative_url }}) requiring manual backup by the user has been the most common private key management scheme by far since its proposal with [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) in 2013. If you have used any [non-custodial]({{ '/guide/glossary/#non-custodial--custodial-wallet' | relative_url }}) bitcoin application you are likely to have experienced the onboarding requirements of manual backups.
 
 When creating a new wallet, you will be asked to manually backup a 12 or 24 word recovery phrase to a *safe place*. Often, as the next step it will ask you to verify that you did save it by having you input the phrase in the correct order.
 

--- a/guide/private-key-management/overview.md
+++ b/guide/private-key-management/overview.md
@@ -104,7 +104,7 @@ Now let's dive in and look at the various schemes that might be suitable for a p
 %}
 
 - [Automatic cloud backup](/guide/private-key-management/cloud-backup/) - no user action required for backup
-- [Manual backup / Recovery phrase](/guide/private-key-management/manual-backup/) - manual backup of a phrase of words
+- [Recovery phrase](/guide/private-key-management/manual-backup/) - manual backup of a phrase of words
 - [External signing device](/guide/private-key-management/external-signing-device/) - keys are held on a separate device
 - [Threshold signatures / Key-sharing](/guide/private-key-management/key-sharing/) - one key is split and distributed
 - [Multi-key](/guide/private-key-management/multi-key/) - several keys jointly control the wallet

--- a/guide/private-key-management/overview.md
+++ b/guide/private-key-management/overview.md
@@ -104,7 +104,7 @@ Now let's dive in and look at the various schemes that might be suitable for a p
 %}
 
 - [Automatic cloud backup](/guide/private-key-management/cloud-backup/) - no user action required for backup
-- [Recovery phrase](/guide/private-key-management/manual-backup/) - manual backup of a phrase of words
+- [Recovery phrase](/guide/private-key-management/recovery-phrase/) - manual backup of a phrase of words
 - [External signing device](/guide/private-key-management/external-signing-device/) - keys are held on a separate device
 - [Threshold signatures / Key-sharing](/guide/private-key-management/key-sharing/) - one key is split and distributed
 - [Multi-key](/guide/private-key-management/multi-key/) - several keys jointly control the wallet

--- a/guide/private-key-management/overview.md
+++ b/guide/private-key-management/overview.md
@@ -104,7 +104,7 @@ Now let's dive in and look at the various schemes that might be suitable for a p
 %}
 
 - [Automatic cloud backup](/guide/private-key-management/cloud-backup/) - no user action required for backup
-- [Recovery phrase](/guide/private-key-management/recovery-phrase/) - manual backup of a phrase of words
+- [Manual backup of recovery phrase](/guide/private-key-management/recovery-phrase/) - manual backup of a phrase of words
 - [External signing device](/guide/private-key-management/external-signing-device/) - keys are held on a separate device
 - [Threshold signatures / Key-sharing](/guide/private-key-management/key-sharing/) - one key is split and distributed
 - [Multi-key](/guide/private-key-management/multi-key/) - several keys jointly control the wallet

--- a/guide/private-key-management/recovery-phrase.md
+++ b/guide/private-key-management/recovery-phrase.md
@@ -16,7 +16,7 @@ Descriptions of schemes suitable for a single user.
 
 -->
 
-# Recovery phrase
+# Manual backup of recovery phrase
 
 A [recovery phrase]({{ '/guide/glossary/#recovery-phrase' | relative_url }}) requiring manual backup by the user has been the most common private key management scheme by far since its proposal with [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) in 2013. If you have used any [non-custodial]({{ '/guide/glossary/#non-custodial--custodial-wallet' | relative_url }}) bitcoin application you are likely to have experienced the onboarding requirements of manual backups.
 

--- a/guide/private-key-management/recovery-phrase.md
+++ b/guide/private-key-management/recovery-phrase.md
@@ -4,7 +4,7 @@ title: Recovery phrase
 description: An overview of personal private key management schemes.
 nav_order: 3
 parent: Private key management
-permalink: /guide/private-key-management/manual-backup/
+permalink: /guide/private-key-management/recovery-phrase/
 image: https://bitcoin.design/assets/images/guide/private-key-management/schemes/page-personal-schemes.jpg
 ---
 


### PR DESCRIPTION
Changing from 'Manual backup / Recovery phrase' on page, and 'Manual backup' in navigation to 
'Recovery phrase' on both.

Text updates in the first sentence on the page still makes it clear it requires manual backup.
All links and references have been updated.

As discussed in #313 