### PR TITLE
Fix minor formatting heading error

### DIFF
--- a/guide/contribute/formatting.md
+++ b/guide/contribute/formatting.md
@@ -88,7 +88,7 @@ There should be whitespace between paragraphs.
 
 ### Links
 
-### External Links
+#### External Links
 
 ```markdown
 [Link to another page](https://bitcoin.org/bitcoin.pdf)


### PR DESCRIPTION
Fix minor formatting error in formatting page. External links should of been H4 when it was H3. See issue below: 

![image](https://user-images.githubusercontent.com/55287964/118650986-9d6f2e80-b817-11eb-9dad-9207d9396173.png)
