### PR TITLE
Remove 'What's in it?' heading on introduction page

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -43,7 +43,7 @@ Illustration sources
 
 We designed this guide to help anyone navigate those complexities—regardless of where they live or work. We can’t imagine every possible use case, but we can help you build for them.
 
-## What's in it?
+---
 
 ### [Getting started]({{ '/guide/getting-started/introduction/' | relative_url }})
 


### PR DESCRIPTION
Minor edit. This heading doesn't really add anything to the page as the list of chapters clearly states that this is what is in the guide. It is just unnecessary visual weight. 

No other chapter intro pages use a heading also so this makes things look that tiniest bit more consistent guide wide. 