### PR TITLE
Cross-referencing the cloud backup case study page

### DIFF
--- a/guide/case-studies/cloud-backup.md
+++ b/guide/case-studies/cloud-backup.md
@@ -39,9 +39,9 @@ Editor's notes
 
 ## Cash account / Daily spending
 
-Imagine a product which tries to solve the problem of quickly and easily sending smaller amounts of money to friends and family, or for small purchases. Ease and speed of use will be important as usage is likely to be on mobile devices and on the go. Users are not expected to be well versed in bitcoin technology or advanced private key management, which makes it reasonable to worry more about self-inflicted loss than from theft.
+Imagine a product which tries to solve the problem of quickly and easily sending smaller amounts of money to friends and family, or for [small purchases]({{ '/guide/getting-started/personal-finance/#day-to-day-spending' | relative_url }}). Ease and speed of use will be important as usage is likely to be on mobile devices and on the go. Users are not expected to be well versed in bitcoin technology or advanced private key management, which makes it reasonable to worry more about self-inflicted loss than from theft.
 
-A single-key scheme with [automatic cloud backup]({{ '/guide/private-key-management/cloud-backup/' | relative_url }}) might be the best choice for the majority of users in this case. For more advanced users you could offer the option to opt-out of automatic cloud backup and instead use a recovery phrase.
+A single-key scheme with [automatic cloud backup]({{ '/guide/private-key-management/cloud-backup/' | relative_url }}) might be the best choice for the majority of users in this case. For more advanced users you could offer the option to opt-out of automatic cloud backup and instead use a [recovery phrase]({{ '/guide/private-key-management/manual-backup/' | relative_url }}).
 
 {% include prototype.html
    link = "https://www.figma.com/proto/SRWlaxbDulsacpPQn2TTri/Case-study-prototypes?node-id=1%3A3&viewport=1357%2C576%2C1&scaling=scale-down"
@@ -113,4 +113,10 @@ The import sequence guides the user through entering the recovery phrase, which 
 
 </div>
 
-You can find a prototype for this case study linked in the image above, and a Figma file with [outline designs here](https://www.figma.com/file/SRWlaxbDulsacpPQn2TTri/Case-study-prototypes?node-id=0%3A1).
+**Case study resources**
+- [Protoype](https://www.figma.com/proto/SRWlaxbDulsacpPQn2TTri/Case-study-prototypes?node-id=1%3A3&viewport=1357%2C576%2C1&scaling=scale-down)
+- [Figma design file](https://www.figma.com/file/SRWlaxbDulsacpPQn2TTri/Case-study-prototypes?node-id=0%3A1)
+- [Use case]({{ '/guide/getting-started/personal-finance/#day-to-day-spending' | relative_url }})
+- [Private key scheme]({{ '/guide/private-key-management/cloud-backup/' | relative_url }})
+- [Backup guidance for users]({{ '/guide/private-key-management/backups/#encrypted-cloud-backup' | relative_url }})
+

--- a/guide/getting-started/personal-finance.md
+++ b/guide/getting-started/personal-finance.md
@@ -92,6 +92,8 @@ For small, frequent payments we generally accept more risk in exchange for conve
 
 Most stores (online and offline) don't accept bitcoin, so buying coffee is not a very realistic use case for most of us. When that time arrives, users who already pay via smartphones app or NFC-enabled credit card can easily switch to Bitcoin wallet apps. A typical scenario could be that users create dedicated mobile bitcoin (and lightning) wallets for on-the-go payments, in addition to having separate wallets for larger amounts. Similar to having a bank account and regularly taking out cash at an ATM, users could refill their mobile wallets. The mobile wallet may use seedless private key storage from a security perspective, meaning that private keys are hidden from the user and stored on the device with an encrypted backup on a cloud storage provider. The primary wallet however, would be more strongly secured with a [hardware wallet]({% link guide/getting-started/hardware.md %}#hardware-wallets) or even a multi-signature configuration. This would mirror the primary focus of convenience over security. Beyond key management, payment interactions could be identical to what users are already familiar with.
 
+For more on this use case, see the [daily spending case study]({{ '/guide/case-studies/cloud-backup/' | relative_url }}).
+
 ## Monthly budgeting
 
 <div class="center" markdown="1">

--- a/guide/getting-started/why-bitcoin-is-unique.md
+++ b/guide/getting-started/why-bitcoin-is-unique.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Why bitcoin is unique
+title: Why Bitcoin is unique
 nav_order: 2
 parent: Getting started
 permalink: /guide/getting-started/why-bitcoin-is-unique/

--- a/guide/getting-started/why-design-for-bitcoin.md
+++ b/guide/getting-started/why-design-for-bitcoin.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Why design for bitcoin
+title: Why design for Bitcoin
 nav_order: 3
 parent: Getting started
 permalink: /guide/getting-started/why-design-for-bitcoin/
@@ -35,7 +35,7 @@ Illustration sources
    layout = "full-width"
 %}
 
-# Why design for bitcoin
+# Why design for Bitcoin
 
 Bitcoin lets designers seeking the next big challenge build a new kind of money and how we send, spend, save, and store that money. Since Bitcoin’s brand has no owner to set it in stone, you can still have a big impact on Bitcoin even if you aren’t a product designer. And that’s just for starters.
 

--- a/guide/private-key-management/backups.md
+++ b/guide/private-key-management/backups.md
@@ -97,7 +97,7 @@ By storing the recovery-phrase in an online location that is encrypted (not in p
 
 **Do**
 - Use an encrypted password manager like 1Password, LastPass, iCloud Keychain
-- Alternatively, use a wallet application with automatic cloud backup
+- Alternatively, use a wallet application with [automatic cloud backup]({{ '/guide/private-key-management/cloud-backup/' | relative_url }})
 
 **Don’t**
 - Screenshot the recovery-phrase and save it in Google Photos, iCloud photos
@@ -106,6 +106,8 @@ By storing the recovery-phrase in an online location that is encrypted (not in p
 **Suitable for**
 - For small amounts (less than a months salary)
 - When you can't wait to set up a new wallet until you are at home
+
+For more on this user experience, see the [daily spending case study]({{ '/guide/case-studies/cloud-backup/' | relative_url }}).
 
 <br>
 

--- a/guide/private-key-management/cloud-backup.md
+++ b/guide/private-key-management/cloud-backup.md
@@ -45,6 +45,8 @@ With most implementations so far, the location will be the keychain or a user-sp
 
 This makes the backup accessible by the user on a new device, should they lose the original, but only accessible by someone that can log into the user’s Apple or Google account.
 
+To see what a user experience with this scheme could look like, see the [daily spending case study]({{ '/guide/case-studies/cloud-backup/' | relative_url }}).
+
 {% include fact/pros.html %}
 
 - Low onboarding friction


### PR DESCRIPTION
Pointing to pages that describe various parts of the case study (and pointing back from those to the case study).
- The page that describes the use case
- The page that describes the private key management scheme used
- The page that describes backup guidance for users

This turns the case study into a more central point where all the different ideas get bundled to form a product.

If people like this, then we can try to apply it for other case studies as well.

Also fixing a bit of B/bitcoin capitalization, the most important thing to get right in the world. Ever.