### PR TITLE
Adjusted sidebar scrollbar (fix for #337)

### DIFF
--- a/_sass/minima/_side-bar.scss
+++ b/_sass/minima/_side-bar.scss
@@ -10,7 +10,7 @@
   padding: 30px 40px;
   max-height: calc(100vh - 61px);
   overflow: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
   box-sizing: border-box;
 
   @include media-query(medium-down) {

--- a/_sass/minima/article/_image-slide-gallery.scss
+++ b/_sass/minima/article/_image-slide-gallery.scss
@@ -7,7 +7,7 @@ article.guide {
     max-width: none !important;
     display: flex;
     overflow: hidden;
-    overflow-x: scroll;
+    overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     scroll-snap-type: x mandatory;
 


### PR DESCRIPTION
I set the sidebar to `overflow-y: auto` so it will have a scrollbar if the content is long enough, but not have a scrollbar if the menu items are all collapsed.