### PR TITLE
Payments / Sending bitcoin intro copy changes

### DIFF
--- a/guide/payments/send.md
+++ b/guide/payments/send.md
@@ -37,16 +37,25 @@ layout = "full-width"
 
 # Sending bitcoin
 
-Sending bitcoin can be a very straightforward or complex flow in a Bitcoin application. People may be sending bitcoin to a known contact, moving it between their wallets on different devices, or making a purchase through a [payment processor]({{ '/guide/getting-started/software/#payment-processors' | relative_url }}).
+Depending on the target audience of your bitcoin application, designing send flows can range in complexity. An application for new users may focus on the simple flow of entering an amount, address and clicking send. An application for more advanced users may include things like coin selection and custom fee setting as extra options. 
 
-Let us look at the main transaction options senders need to configure when moving bitcoin:
+Below are the must-haves in a sending bitcoin design flow:
 
-- **Amount** — How much to send
-- **Recipient address** — Where to send the bitcoin
-- **Coin selection** — Which coins/inputs to use (optional)
-- **Fee settings** — Prioritize fast confirmation or low cost (optional)
+- **Amount** - The amount of bitcoin the user is sending.
+- **Receiver address** - The Bitcoin Address the user is sending their bitcoin.
+- **Network fee** - Display to the user the current Bitcoin network fee they will be paying for this send.
 
-You do not need to follow the order below. Feel free to tailor the configuration's order for the payment to what best serves your users. For example, you may make users set the amount before they enter the address.
+Some optional, more complex, features you may include:
+
+- **Description** - Let the user add a description detailing what this send is for. 
+- **Coin selection** - Which coins/inputs, also called UTXOs, to use in this send.
+- **Custom fees** - Let the user set custom Bitcoin network fees.
+- **Fee bumping** - Let the user make use of fee bumping, or replace-by-fee (RBF) for this send. 
+- **Batch sending** - Allow the user to send to more than one bitcoin address in this send.
+
+A send flow should offer more complex features as an advanced option at the least. New users can then take advantage of these features as they become more comfortable sending bitcoin. 
+
+The rest of this section covers sending bitcoin design considerations and the process in more detail.
 
 ## Get the recipient address
 

--- a/guide/payments/send.md
+++ b/guide/payments/send.md
@@ -42,7 +42,7 @@ Depending on the target audience of your bitcoin application, designing send flo
 Below are the must-haves in a sending bitcoin design flow:
 
 - **Amount** - The amount of bitcoin the user is sending.
-- **Receiver address** - The Bitcoin Address the user is sending their bitcoin.
+- **Receiver address** - The Bitcoin Address the user is sending their bitcoin to.
 - **Network fee** - Display to the user the current Bitcoin network fee they will be paying for this send.
 
 Some optional, more complex, features you may include:


### PR DESCRIPTION
Some changes to the top section copy of the [payments/sending](https://bitcoin.design/guide/payments/send/) section of the guide. I am planning on going through this page one section at a time to make the PR review process more manageable. Let me know if reviewers prefer this approach or would rather I go over the whole section in one big PR. 

**Changes made**

- Re-worded the content (most notable the opening paragraph) to put more of a emphasis on _designing send flows_ rather than having it sound like a general _sending bitcoin_ overview. With the context of the guide in mind this makes more sense. A few areas of this section read like an explanation of sending bitcoin without the context of _designing_ sending bitcoin flows like it should. 
- Broke the the list up into must-haves and optional, advanced extras. Added several features, mostly to the advanced section. Content will need to be added in the later sections covering these. 

