### PR TITLE
Payments / Sending bitcoin 'recipient address' copy changes

### DIFF
--- a/guide/payments/send.md
+++ b/guide/payments/send.md
@@ -48,7 +48,7 @@ Let us look at the main transaction options senders need to configure when movin
 
 You do not need to follow the order below. Feel free to tailor the configuration's order for the payment to what best serves your users. For example, you may make users set the amount before they enter the address.
 
-## Get the recipient address
+## Get the receivers address
 
 <div class="center" markdown="1">
 {% include image.html
@@ -60,9 +60,9 @@ You do not need to follow the order below. Feel free to tailor the configuration
    layout = "float-right-desktop"
 %}
 
-To send a payment on the Bitcoin blockchain, the sender needs to obtain an address from the recipient. Since Bitcoin [addresses]({{ '/guide/glossary/#address' | relative_url }}) are long and seemingly random, they are best shared by copying and pasting in plain text, as a [payment link]({{ '/guide/foundations/wallet-interoperability/#payment-links' | relative_url }}), or as a scannable [QR Code]({{ '/guide/foundations/wallet-interoperability/#qr-codes' | relative_url }}).
+The first step in a sending bitcoin flow is getting the receivers [Bitcoin address](https://bitcoin.design/guide/glossary/#address). To send a bitcoin payment, the receiver needs to generate and share a bitcoin address with the sender. Bitcoin addresses are best shared as text, as a [payment link](https://bitcoin.design/guide/foundations/wallet-interoperability/#payment-links) or as a scannable [QR code](https://bitcoin.design/guide/foundations/wallet-interoperability/#qr-codes). For optimal privacy, Bitcoin addresses should be shared over secure communication channels. This could be recommended to users at the start of the sending user flow. 
 
-The receiver does this by generating a new address in their wallet application, then sharing it with the sender. If the sender and receiver are physically close to each other, scanning the receiver's address as a QR Code will be easy. Still, if they are not, they can send the address as text in any regular communication tool like email, SMS, etc.
+Design considerations for generating and sharing an address can be found in the [receiving bitcoin]( https://bitcoin.design/guide/payments/receive/#requesting-bitcoin ) section.
 </div>
 
 ## Inputting an address

--- a/guide/payments/send.md
+++ b/guide/payments/send.md
@@ -60,7 +60,9 @@ You do not need to follow the order below. Feel free to tailor the configuration
    layout = "float-right-desktop"
 %}
 
-The first step in a sending bitcoin flow is getting the receivers [Bitcoin address](https://bitcoin.design/guide/glossary/#address). To send a bitcoin payment, the receiver needs to generate and share a bitcoin address with the sender. Bitcoin addresses are best shared as text, as a [payment link](https://bitcoin.design/guide/foundations/wallet-interoperability/#payment-links) or as a scannable [QR code](https://bitcoin.design/guide/foundations/wallet-interoperability/#qr-codes). For optimal privacy, Bitcoin addresses should be shared over secure communication channels. This could be recommended to users at the start of the sending user flow. 
+The first step in a sending bitcoin flow is getting the receivers [Bitcoin address](https://bitcoin.design/guide/glossary/#address). To send a bitcoin payment, the receiver needs to generate and share a bitcoin address with the sender. Bitcoin addresses are best shared as text, a [payment link](https://bitcoin.design/guide/foundations/wallet-interoperability/#payment-links) or a scannable [QR code](https://bitcoin.design/guide/foundations/wallet-interoperability/#qr-codes). 
+
+For optimal privacy, Bitcoin addresses should be shared over secure communication channels. This could be recommended to users at the start of the sending user flow. 
 
 Design considerations for generating and sharing an address can be found in the [receiving bitcoin]( https://bitcoin.design/guide/payments/receive/#requesting-bitcoin ) section.
 </div>


### PR DESCRIPTION
Relates to #340.

Some changes to the recipient address copy of the payments/sending section of the guide. 

**Changes made**

- Changed title from _recipient address_ to _receivers address_. 

This section currently switches been calling the recipient and receiver terminology. It would be best to stick with one. Receiver is more plain English and clearer in my view so I used this. 

- Trimmed down from one paragraph to two.

The second paragraph doesn't add much to the content. This page is focused on the send flow of which the generating of an address details are part of the receive flow. I Referenced to that section for details on that rather than explain it here. The first paragraph briefly explains the process anyways - the additional detail is irrelevant and seems a bit fluffy.

I added an actionable design insight to this section around how the address should be shared with the sender. It is important to have points like this to prevent the section from just reading like an overview of the process. This was the only design input I could think of for this part of the sending bitcoin user flow. We could also mention that your application should have the ability to scan QR codes as this is part of _getting the receivers address_ but this would overlap with the next section. 
