### PR TITLE
 Minor fix: Add missing break line on onboarding/manual backup page

### DIFF
--- a/guide/onboarding/manual-backup.md
+++ b/guide/onboarding/manual-backup.md
@@ -261,4 +261,6 @@ You could also ask users to select (or manually type out) a random word from the
 
 </div>
 
+---
+
 The next section will highlight some options for [restoring a wallet]({{ 'guide/onboarding/restoring-a-wallet' | relative_url }}).


### PR DESCRIPTION
Page was missing a break line separating the content and the link to the next page in the chapter.