### PR TITLE
 Minor fix: Add missing break line on protecting a wallet page

### DIFF
--- a/guide/onboarding/protecting-a-wallet.md
+++ b/guide/onboarding/protecting-a-wallet.md
@@ -163,4 +163,6 @@ Privacy in bitcoin payments goes far beyond hiding balances and other sensitive 
 
 By including UX patterns for hiding information pattern wallets, we give users a greater sense of control and comfort in any situation. They have the freedom to decide whether or not they want their information visible.
 
+---
+
 Now let's look at the different ways a user might go about [funding a wallet]({{ 'guide/onboarding/funding-a-wallet' | relative_url }}).


### PR DESCRIPTION
Page was missing a break line separating the content and the link to the next page in the chapter.