### PR TITLE
Added missing SEO description tags and H1 title fix

### DIFF
--- a/guide/case-studies/cloud-backup.md
+++ b/guide/case-studies/cloud-backup.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Daily spending
+description: A mobile Bitcoin wallet case study using automatic cloud backup as a private key management scheme.
 nav_order: 1
 parent: Case studies
 permalink: /guide/case-studies/cloud-backup/
@@ -37,7 +38,7 @@ Editor's notes
 
 -->
 
-## Cash account / Daily spending
+# Cash account / Daily spending
 
 Imagine a product which tries to solve the problem of quickly and easily sending smaller amounts of money to friends and family, or for [small purchases]({{ '/guide/designing-products/personal-finance/#day-to-day-spending' | relative_url }}). Ease and speed of use will be important as usage is likely to be on mobile devices and on the go. Users are not expected to be well versed in bitcoin technology or advanced private key management, which makes it reasonable to worry more about self-inflicted loss than from theft.
 

--- a/guide/case-studies/savings-account.md
+++ b/guide/case-studies/savings-account.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Savings account
+description: Case study for a Bitcoin wallet designed for storing medium amounts.
 nav_order: 2
 parent: Case studies
 permalink: /guide/case-studies/savings-account/
@@ -39,7 +40,7 @@ Editor's notes
 
 -->
 
-## Savings account
+# Savings account
 
 In this section, we are looking at a product that is meant to be a replacement for what a bank would call a [savings]({{ '/guide/designing-products/personal-finance/#savings' | relative_url }}) account where the user might store wealth long term. Safeguards against loss will be a higher priority than with a frequent spending product, and we might therefore accept more friction both when setting up the wallet and when transacting. If users have no prior Bitcoin knowledge we should expect to spend a significant effort educating them to put them in a position to safely operate the wallet product.
 

--- a/guide/case-studies/shared-account.md
+++ b/guide/case-studies/shared-account.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Shared account
+description: Bitcoin wallet design case study for accounts managed together by multiple owners.
 nav_order: 4
 parent: Case studies
 permalink: /guide/case-studies/shared-account/
@@ -40,7 +41,7 @@ Editor's notes
 
 -->
 
-## Shared account
+# Shared account
 
 A common real-world use case for shared accounts are couples managing their monthly spending, with both parties being able to spend from the account. For this situation we could consider the following private key management schemes:
 

--- a/guide/case-studies/upgradeable-wallet.md
+++ b/guide/case-studies/upgradeable-wallet.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Upgradeable account
+description: UX case study for a Bitcoin wallet with multiple private key management schemes.
 nav_order: 3
 parent: Case studies
 permalink: /guide/case-studies/upgradeable-wallet/
@@ -30,7 +31,7 @@ Editor's notes
 
 -->
 
-## Upgradeable wallet
+# Upgradeable wallet
 
 Although it is generally easier to build a great experience with a specific [use case]({{ '/guide/designing-products/personal-finance/' | relative_url }}) in mind, let's look at a case where we would like to make a wallet that is made for a broad range of uses and audiences. It needs to be suitable both for beginners and expanding users, and for holding anything between small and significant amounts. How do we choose a single private key management scheme for this situation?
 

--- a/guide/designing-products/common-user-flows.md
+++ b/guide/designing-products/common-user-flows.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Common user flows
+description: Overview of the most common user activities in Bitcoin applications.
 nav_order: 7
 parent: Designing Bitcoin products
 permalink: /guide/designing-products/common-user-flows/

--- a/guide/designing-products/designing-products.md
+++ b/guide/designing-products/designing-products.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Designing Bitcoin products
+description: Learn fundamentals, techniques and best practices for designing great Bitcoin UX.
 nav_order: 3
 has_children: true
 permalink: /guide/designing-products/introduction/

--- a/guide/designing-products/open-design.md
+++ b/guide/designing-products/open-design.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Open design
+description: What it means to participate in open design in the Bitcoin ecosystem.
 nav_order: 2
 parent: Designing Bitcoin products
 permalink: /guide/designing-products/open-design/

--- a/guide/designing-products/personal-finance.md
+++ b/guide/designing-products/personal-finance.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Personal finance
+description: How Bitcoin applications and usage overlap with traditional personal finance management.
 nav_order: 6
 parent: Designing Bitcoin products
 permalink: /guide/designing-products/personal-finance/

--- a/guide/designing-products/usage-life-cycle.md
+++ b/guide/designing-products/usage-life-cycle.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Usage life cycle
+description: A framework for how users learn about Bitcoin and gain expertise with Bitcoin applications.
 nav_order: 5
 parent: Designing Bitcoin products
 permalink: /guide/designing-products/usage-life-cycle/

--- a/guide/designing-products/user-research.md
+++ b/guide/designing-products/user-research.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: User research
+description: Bitcoin user research is unique due to the decentralized and public nature of the network.
 nav_order: 4
 parent: Designing Bitcoin products
 has_children: true

--- a/guide/designing-products/why-design-for-bitcoin.md
+++ b/guide/designing-products/why-design-for-bitcoin.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Why design for Bitcoin
+description: Be on the cutting-edge of technology and open-design by working in the Bitcoin ecosystem.
 nav_order: 1
 parent: Designing Bitcoin products
 permalink: /guide/designing-products/why-design-for-bitcoin/

--- a/guide/getting-started/getting-started.md
+++ b/guide/getting-started/getting-started.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Getting started
+description: Learn the basics of Bitcoin, from a history of visuals to available software and hardware categories.
 nav_order: 2
 has_children: true
 permalink: /guide/getting-started/introduction/

--- a/guide/getting-started/hardware.md
+++ b/guide/getting-started/hardware.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Hardware overview
+description: List of the main categories of Bitcoin hardware, from wallets to miners.
 nav_order: 12
 parent: Getting started
 permalink: /guide/getting-started/hardware/

--- a/guide/getting-started/software.md
+++ b/guide/getting-started/software.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Software overview
+description: List of the main categories of Bitcoin software, from wallets to nodes.
 nav_order: 11
 parent: Getting started
 permalink: /guide/getting-started/software/

--- a/guide/getting-started/technology-primer.md
+++ b/guide/getting-started/technology-primer.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Technology primer
+description: Learn the basics of Bitcoin technology in a series of simple explanations.
 nav_order: 10
 parent: Getting started
 permalink: /guide/getting-started/technology-primer/

--- a/guide/getting-started/visual-language.md
+++ b/guide/getting-started/visual-language.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Visual language
+description: A short history of the visuals that we associate with Bitcoin, from the first symbol to the HODL meme.
 nav_order: 5
 parent: Getting started
 permalink: /guide/getting-started/visual-language/

--- a/guide/getting-started/why-bitcoin-is-unique.md
+++ b/guide/getting-started/why-bitcoin-is-unique.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Why Bitcoin is unique
+description: Overview of the most important traits that give Bitcoin its special role as a digital payment network.
 nav_order: 2
 parent: Getting started
 permalink: /guide/getting-started/why-bitcoin-is-unique/

--- a/guide/onboarding/automatic-cloud-backup.md
+++ b/guide/onboarding/automatic-cloud-backup.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Automatic cloud backup
-description: How to backup a recovery phrase automatically
+description: How to backup a bitcoin wallet recovery phrase automatically via cloud storage service providers.
 grand_parent: Onboarding
 parent: Backing up a recovery phrase
 nav_order: 1

--- a/guide/onboarding/backing-up-a-recovery-phrase.md
+++ b/guide/onboarding/backing-up-a-recovery-phrase.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Backing up a recovery phrase
-description: Handling recovery phrases during onboarding
+description: Handling recovery phrases during onboarding.
 parent: Onboarding
 has_children: true
 nav_order: 3

--- a/guide/onboarding/creating-a-new-wallet.md
+++ b/guide/onboarding/creating-a-new-wallet.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Creating a new wallet
-description: Steps to take when creating a new wallet
+description: Steps to take when creating a new wallet, and tips for a great user experience.
 parent: Onboarding
 nav_order: 2
 permalink: /guide/onboarding/creating-a-new-wallet/

--- a/guide/onboarding/funding-a-wallet.md
+++ b/guide/onboarding/funding-a-wallet.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Funding a wallet
-description: Outline of the ways users are likely to fund a wallet
+description: Outline of the ways users are likely to fund a wallet, from direct purchase to bitcoin gift cards.
 parent: Onboarding
 nav_order: 7
 permalink: /guide/onboarding/funding-a-wallet/

--- a/guide/onboarding/manual-backup.md
+++ b/guide/onboarding/manual-backup.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Manual backup
-description: How to backup a recovery phrase manually
+description: How to manually back up the recovery phrase of a Bitcoin wallet.
 grand_parent: Onboarding
 parent: Backing up a recovery phrase
 nav_order: 2

--- a/guide/onboarding/protecting-a-wallet.md
+++ b/guide/onboarding/protecting-a-wallet.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Protecting a wallet
-description: Adding extra layers of security
+description: How extra layers of security can be added to Bitcoin applications via PINs, Face Id, and other techniques.
 parent: Onboarding
 nav_order: 6
 permalink: /guide/onboarding/protecting-a-wallet/

--- a/guide/onboarding/restoring-a-wallet.md
+++ b/guide/onboarding/restoring-a-wallet.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Restoring a wallet
-description: Options for restoring a wallet
+description: Options for restoring a wallet, from automatic cloud backup to recovery phrases, and more.
 parent: Onboarding
 nav_order: 4
 permalink: /guide/onboarding/restoring-a-wallet/

--- a/guide/payments/coin-selection.md
+++ b/guide/payments/coin-selection.md
@@ -1,6 +1,7 @@
 ---
 layout: guide
 title: Coin Selection
+description: A primer on how UTXOs are chosen to fund new bitcoin transactions.
 nav_order: 1
 grand_parent: Payments
 parent: Sending bitcoin

--- a/guide/private-key-management/cloud-backup.md
+++ b/guide/private-key-management/cloud-backup.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Automatic cloud backup
-description: An overview of personal private key management schemes.
+description: Overview of how recovery phrases and other wallet data can be securely stored with cloud storage service providers.
 nav_order: 2
 parent: Private key management
 permalink: /guide/private-key-management/cloud-backup/

--- a/guide/private-key-management/external-signing-device.md
+++ b/guide/private-key-management/external-signing-device.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: External signing device
-description: An overview of personal private key management schemes.
+description: What hardware wallets are and their role in securing bitcoin.
 nav_order: 4
 parent: Private key management
 permalink: /guide/private-key-management/external-signing-device/

--- a/guide/private-key-management/introduction.md
+++ b/guide/private-key-management/introduction.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Private key management
-description: An overview of private key management schemes, including descriptions of  available approaches, some advice and best practices.
+description: An overview of private key management schemes, including descriptions of available approaches, some advice and best practices.
 nav_order: 5
 has_children: true
 permalink: /guide/private-key-management/introduction/

--- a/guide/private-key-management/manual-backup.md
+++ b/guide/private-key-management/manual-backup.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Manual backup
-description: An overview of personal private key management schemes.
+description: An explainer of manual backup for recovery phrases of Bitcoin wallets.
 nav_order: 3
 parent: Private key management
 permalink: /guide/private-key-management/manual-backup/

--- a/guide/private-key-management/multi-key.md
+++ b/guide/private-key-management/multi-key.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Multi-key
-description: An overview of personal private key management schemes.
+description: Learn the basics of multi-signature Bitcoin wallets.
 nav_order: 6
 parent: Private key management
 permalink: /guide/private-key-management/multi-key/


### PR DESCRIPTION
Added description tags to pages that either didn't have any, or had duplicates.
Made a few description longs to add more keywords.
Changed H2 to H1 tags in the case study pages.

This came from a [link](https://app.neilpatel.com/en/seo_analyzer/site_audit?domain=bitcoin.design&view=all) Paulo posted with a summary of SEO issues. Just picking off some low-hanging fruit.