### PR TITLE
Fix to add 💪 to a weak site description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@
 
 title: Bitcoin Design
 email: no-reply@bitcoindesign.org
-description: "Bitcoin Design aims to be a free open-source community resource that will help designers and developers working on bitcoin-products to create better experiences, faster."
+description: "Bitcoin Design is a free open-source community resource that helps designers and developers working on bitcoin-products to create better experiences, faster."
 # baseurl: "Guide" # Only for gh-pages. Comment this line to run the website on localhost:4000
 url: "https://bitcoin.design" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb


### PR DESCRIPTION
### Problem
The current site description feels a bit weak, esp after launch and all what we've done in the past 12 months.

### Solution
Own what we ARE doing. We're 1600+ slack members, people are getting jobs from [Bitcoin UI Kit](http://bitcoinuikit.com) and it has over 700 downloads. [Bitcoin Icons](https://bitcoinicons.com) is being added to a bunch of collaborations. Of which we have like [Specter](https://github.com/BitcoinDesign/Meta/issues/69), [Zeus](https://github.com/BitcoinDesign/Meta/issues/70), [LBE](https://github.com/BitcoinDesign/Meta/issues/113), [LDK](https://github.com/BitcoinDesign/Meta/issues/89), [OpenSats](https://github.com/BitcoinDesign/Meta/issues/108)...

Big tings ah gwan so LFG!

### Result
Bitcoin Design ~~aims to be~~ **is** a free open-source community resource that ~~will help~~ **helps** designers and developers working on bitcoin-products to create better experiences, faster.