### PR TITLE
Add UI kit to the projects page

### DIFF
--- a/assets/images/contribute/bitcoin-ui-kit.svg
+++ b/assets/images/contribute/bitcoin-ui-kit.svg
@@ -1,0 +1,22 @@
+<svg width="75" height="75" viewBox="0 0 75 75" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17 6C17 2.68629 19.6863 0 23 0H52C55.3137 0 58 2.68629 58 6V39H56V6C56 3.79086 54.2091 2 52 2H23C20.7909 2 19 3.79086 19 6V43H17V6ZM56 49V69C56 71.2091 54.2091 73 52 73H23C20.7909 73 19 71.2091 19 69V63H17V69C17 72.3137 19.6863 75 23 75H52C55.3137 75 58 72.3137 58 69V49H56Z" fill="#6490E3"/>
+<rect x="27" y="67" width="21" height="2" rx="1" fill="#6490E3"/>
+<rect x="23" y="6" width="29" height="25" rx="3" fill="#6490E3"/>
+<rect width="30" height="8" rx="3" transform="matrix(1 0 0 -1 44 48)" stroke="#6490E3" stroke-width="2"/>
+<rect width="9" height="21" rx="3" transform="matrix(1 0 0 -1 65 33)" stroke="#6490E3" stroke-width="2" stroke-linejoin="round"/>
+<rect width="8" height="8" rx="4" transform="matrix(1 0 0 -1 44 62)" fill="#6490E3"/>
+<rect width="3" height="3" rx="1.5" transform="matrix(1 0 0 -1 68 18)" fill="#6490E3"/>
+<rect width="3" height="3" rx="1.5" transform="matrix(1 0 0 -1 68 24)" fill="#6490E3"/>
+<rect width="3" height="3" rx="1.5" transform="matrix(1 0 0 -1 68 30)" fill="#6490E3"/>
+<rect width="23" height="20" rx="3" transform="matrix(1 0 0 -1 1 63)" stroke="#6490E3" stroke-width="2"/>
+<rect width="15" height="2" rx="1" transform="matrix(1 0 0 -1 5 49)" fill="#6490E3"/>
+<rect width="4" height="2" rx="1" transform="matrix(1 0 0 -1 47 45)" fill="#6490E3"/>
+<rect width="18" height="2" rx="1" transform="matrix(1 0 0 -1 53 45)" fill="#6490E3"/>
+<rect width="15" height="2" rx="1" transform="matrix(1 0 0 -1 5 54)" fill="#6490E3"/>
+<rect width="15" height="2" rx="1" transform="matrix(1 0 0 -1 5 59)" fill="#6490E3"/>
+<rect width="12" height="4" rx="1" transform="matrix(1 0 0 -1 0 12)" fill="#6490E3"/>
+<rect width="12" height="4" rx="1" transform="matrix(1 0 0 -1 0 21)" fill="#6490E3"/>
+<rect width="12" height="4" rx="1" transform="matrix(1 0 0 -1 0 30)" fill="#6490E3"/>
+<rect width="10" height="5" rx="1" transform="matrix(1 0 0 -1 65 62)" fill="#6490E3"/>
+<rect width="10" height="5" rx="1" transform="matrix(1 0 0 -1 65 70)" fill="#6490E3"/>
+</svg>

--- a/projects.md
+++ b/projects.md
@@ -32,6 +32,19 @@ projects:
         link: https://www.figma.com/community/file/948545404023677970/Bitcoin-icon-set
       - name: Github
         link: https://github.com/BitcoinDesign/Bitcoin-Icons
+  - name: Bitcoin UI Kit
+    description: A complete design system to serve as a foundation for wallet concepts, prototypes and application development.
+    image:
+      url: /assets/images/contribute/bitcoin-ui-kit.svg
+      width: 75
+      height: 75
+    links:
+      - name: Site
+        link: https://bitcoinuikit.com
+      - name: Figma
+        link: https://www.figma.com/community/file/916680391812923706/Bitcoin-Wallet-UI-Kit-(work-in-progress)
+      - name: Github
+        link: https://github.com/GBKS/bitcoin-wallet-ui-kit
 collaborations:
   - name: Specter
     description: A watch-only coordinator for multi-signature and single-key Bitcoin wallets.


### PR DESCRIPTION
This adds the UI kit as a community project to the /projects page.

The UI kit has turned into a tool that has been used multiple times by community members to kick off design projects, and designs from the kit are also used in the guide. So while the maintenance of the kit is still done by me (which would be great to expand), I think it has otherwise turned into something bigger. Therefore I think it could be added the projects page.