### PR TITLE
PKM - Add illustration sources

### DIFF
--- a/guide/private-key-management/backups.md
+++ b/guide/private-key-management/backups.md
@@ -17,7 +17,7 @@ A guide meant to lower the barrier for first time users of self-custody wallets.
 
 Illustration sources
 
-//
+https://www.figma.com/community/file/995256542920917246/BDG---Private-key-management-illustrations
 
 -->
 

--- a/guide/private-key-management/cloud-backup.md
+++ b/guide/private-key-management/cloud-backup.md
@@ -9,6 +9,19 @@ image: https://bitcoin.design/assets/images/guide/private-key-management/cloud-b
 main_classes: -no-top-padding
 ---
 
+<!--
+
+Editor's notes
+
+Description of what an automatic cloud backup scheme consists of.
+
+Illustration sources
+
+https://www.figma.com/community/file/888680264445459448
+https://www.figma.com/community/file/995256542920917246/BDG---Private-key-management-illustrations
+
+-->
+
 {% include picture.html
    image = "/assets/images/guide/private-key-management/cloud-backup/cloud-backup.jpg"
    retina = "/assets/images/guide/private-key-management/cloud-backup/cloud-backup@2x.jpg"

--- a/guide/private-key-management/external-signing-device.md
+++ b/guide/private-key-management/external-signing-device.md
@@ -13,7 +13,12 @@ main_classes: -no-top-padding
 
 Editor's notes
 
-Descriptions of schemes suitable for a single user.
+Description of what an external signing device scheme consists of.
+
+Illustration sources
+
+https://www.figma.com/community/file/888680264445459448
+https://www.figma.com/community/file/995256542920917246/BDG---Private-key-management-illustrations
 
 -->
 

--- a/guide/private-key-management/introduction.md
+++ b/guide/private-key-management/introduction.md
@@ -16,6 +16,10 @@ Editor's notes
 A brief introduction and summary of all pages in this section. The idea is that readers
 scan this page to get an overview of the section and then decide which topics to dive into.
 
+Illustration sources
+
+https://www.figma.com/community/file/995256542920917246/BDG---Private-key-management-illustrations
+
 -->
 
 {% include picture.html

--- a/guide/private-key-management/manual-backup.md
+++ b/guide/private-key-management/manual-backup.md
@@ -13,7 +13,12 @@ main_classes: -no-top-padding
 
 Editor's notes
 
-Descriptions of schemes suitable for a single user.
+Description of what manual backup / recovery phrase scheme consists of.
+
+Illustration sources
+
+https://www.figma.com/community/file/888680264445459448
+https://www.figma.com/community/file/995256542920917246/BDG---Private-key-management-illustrations
 
 -->
 

--- a/guide/private-key-management/multi-key.md
+++ b/guide/private-key-management/multi-key.md
@@ -13,7 +13,12 @@ main_classes: -no-top-padding
 
 Editor's notes
 
-Descriptions of multi-key schemes.
+Description of what multi-key scheme consists of.
+
+Illustration sources
+
+https://www.figma.com/community/file/888680264445459448
+https://www.figma.com/community/file/995256542920917246/BDG---Private-key-management-illustrations
 
 -->
 

--- a/guide/private-key-management/overview.md
+++ b/guide/private-key-management/overview.md
@@ -15,6 +15,10 @@ Editor's notes
 
 An overview of what different private key management schemes there are, and how to choose one depending on use case.
 
+Illustration sources
+
+https://www.figma.com/community/file/995256542920917246/BDG---Private-key-management-illustrations
+
 -->
 
 {% include picture.html


### PR DESCRIPTION
All pages should have editor's notes that include links to illustrations used, see #408.
This PR adds that for the Private key management chapter.