### PR TITLE
Case studies - Add illustration sources

### DIFF
--- a/guide/case-studies/cloud-backup.md
+++ b/guide/case-studies/cloud-backup.md
@@ -33,8 +33,13 @@ importImages:
 ---
 
 <!--
-
 Editor's notes
+
+Daily spending case study.
+
+Illustration sources
+
+https://www.figma.com/community/file/968416729557947210
 
 -->
 

--- a/guide/case-studies/introduction.md
+++ b/guide/case-studies/introduction.md
@@ -13,6 +13,12 @@ image: https://bitcoin.design/assets/images/guide/case-studies/page-case-studies
 
 Editor's notes
 
+Chapter overview for the various case studies.
+
+Illustration sources
+
+https://www.figma.com/community/file/995256542920917246/BDG---Private-key-management-illustrations
+
 -->
 
 {% include picture.html

--- a/guide/case-studies/savings-account.md
+++ b/guide/case-studies/savings-account.md
@@ -38,6 +38,12 @@ images:
 
 Editor's notes
 
+Savings account case study.
+
+Illustration sources
+
+https://www.figma.com/community/file/968416729557947210
+
 -->
 
 # Savings account

--- a/guide/case-studies/shared-account.md
+++ b/guide/case-studies/shared-account.md
@@ -39,6 +39,12 @@ images:
 
 Editor's notes
 
+Shared account case study.
+
+Illustration sources
+
+https://www.figma.com/community/file/968416729557947210
+
 -->
 
 # Shared account

--- a/guide/case-studies/upgradeable-wallet.md
+++ b/guide/case-studies/upgradeable-wallet.md
@@ -29,6 +29,12 @@ images:
 
 Editor's notes
 
+Upgradeable wallet case study.
+
+Illustration sources
+
+https://www.figma.com/community/file/968416729557947210
+
 -->
 
 # Upgradeable wallet


### PR DESCRIPTION
All pages should have links to illustration sources, see #408.
This PR adds it to the case studies chapter. 