### PR TITLE
Fix broken links to the Glossary/Address section

### DIFF
--- a/guide/glossary/wallet.md
+++ b/guide/glossary/wallet.md
@@ -33,7 +33,7 @@ All bitcoin-related data derived from and associated with a single recovery phra
 
 Hierarchical Deterministic wallets, or HD wallets, can create infinite keypairs organized in a tree-structure (hierarchical) from a single (deterministic) controlling keypair. They were introduced and defined in [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and then expanded with [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) which added the ability to handle multiple *accounts* in one wallet.
 
-**Technicalities** - There are different bitcoin address formats (see [address](#address)). They have to be held in different branches of the HD wallet but can be controlled by the same recovery phrase.
+**Technicalities** - There are different bitcoin address formats (see [address]({{ '/guide/glossary/address' | relative_url }})). They have to be held in different branches of the HD wallet but can be controlled by the same recovery phrase.
 
 #### Hardware wallet
 

--- a/guide/payments/receive.md
+++ b/guide/payments/receive.md
@@ -50,7 +50,7 @@ The simplest way to receive bitcoin is by generating and sharing a Bitcoin addre
 </div>
 
 {% include tip/tip.html %}
-There are several types of addresses. Sharing one that is incompatible with the sender's wallet application can prevent a successful payment. Read more about [address compatibility]({{ '/guide/glossary/#address-compatibility' | relative_url }}) issues in the glossary.
+There are several types of addresses. Sharing one that is incompatible with the sender's wallet application can prevent a successful payment. Read more about [address compatibility]({{ '/guide/glossary/address/#address-compatibility' | relative_url }}) issues in the glossary.
 {% include tip/close.html %}
 
 ## Inputting additional payment details

--- a/guide/payments/send.md
+++ b/guide/payments/send.md
@@ -61,7 +61,7 @@ You do not need to follow the order below. Feel free to tailor the configuration
    layout = "float-right-desktop"
 %}
 
-To send a payment on the Bitcoin blockchain, the sender needs to obtain an address from the recipient. Since Bitcoin [addresses]({{ '/guide/glossary/#address' | relative_url }}) are long and seemingly random, they are best shared by copying and pasting in plain text, as a [payment link]({{ '/guide/designing-products/wallet-interoperability/#payment-links' | relative_url }}), or as a scannable [QR Code]({{ '/guide/designing-products/wallet-interoperability/#qr-codes' | relative_url }}).
+To send a payment on the Bitcoin blockchain, the sender needs to obtain an address from the recipient. Since Bitcoin [addresses]({{ '/guide/glossary/address' | relative_url }}) are long and seemingly random, they are best shared by copying and pasting in plain text, as a [payment link]({{ '/guide/designing-products/wallet-interoperability/#payment-links' | relative_url }}), or as a scannable [QR Code]({{ '/guide/designing-products/wallet-interoperability/#qr-codes' | relative_url }}).
 
 The receiver does this by generating a new address in their wallet application, then sharing it with the sender. If the sender and receiver are physically close to each other, scanning the receiver's address as a QR Code will be easy. Still, if they are not, they can send the address as text in any regular communication tool like email, SMS, etc.
 </div>

--- a/guide/payments/transactions.md
+++ b/guide/payments/transactions.md
@@ -61,7 +61,7 @@ The sender needs a valid address for the payment to be sent to. This can be shar
 The wallet application guides the sender through collecting the required information (address and amount) and any optional configurations (which coins to send, fee options) in order to create a transaction.
 
 #### 3. Signing
-The transaction needs to be signed by the [private key(s)]({{ '/guide/glossary/#private-key' | relative_url }}) of the input [address(es)]({{ '/guide/glossary/#address' | relative_url }}) to be valid. The signing is often done in the same application after the transaction has created and configured, but this does not have to be the case.
+The transaction needs to be signed by the [private key(s)]({{ '/guide/glossary/#private-key' | relative_url }}) of the input [address(es)]({{ '/guide/glossary/address' | relative_url }}) to be valid. The signing is often done in the same application after the transaction has created and configured, but this does not have to be the case.
 
 #### 4. Broadcasting
 The transaction is broadcasted to a Bitcoin node, normally the one the wallet is connected to.


### PR DESCRIPTION
As I was reading the guide, I noticed a few links pointing to an anchor within the `Glossary` page that do not exist (or no longer exists). I believe they were meant to link to the dedicated `Address` section in the `Glossary`.
