### PR TITLE
Added some info on Eltoo / hardware wallets to hardware overview

### DIFF
--- a/guide/getting-started/hardware.md
+++ b/guide/getting-started/hardware.md
@@ -81,6 +81,8 @@ Bitcoin hardware wallets, also known as external signers, act like Bitcoin centr
 
 Hardware wallets only exchange non-sensitive information with external devices. Sensitive processes, such as signing a transaction to open a Lightning network payment channel, happen on the device. Most interactions with hardware wallets happen via desktop [software, like wallets]({{ '/guide/getting-started/software/#wallets' | relative_url }}). 
 
+A not yet implemented enforcement layer for Lightning called [Eltoo](https://bitcoinops.org/en/topics/eltoo/) may also allow hardware wallets to backup payment channel states.
+
 ## Nodes
 
 A node is a device that participates in a network. There are two types of nodes to understand: A Bitcoin node which participates in the Bitcoin network, and a Lightning node which participates in the Lightning network. For a deeper dive into what purpose these nodes serve check out the [technology primer]({{ '/guide/getting-started/technology-primer/' | relative_url }}).


### PR DESCRIPTION
From Optech

> Another consequence of LN channels without penalties is that LN nodes using eltoo only need to store the latest state. For certain devices that lack large amounts of persistent storage (for example, hardware wallets), they may not be able to store enough data to effectively use penalty-based LN—but as long as they can store a few kB, they should be able to use eltoo-based LN.