### PR TITLE
Fix typo 'Hardware' -> 'Software'

### DIFF
--- a/guide/glossary/wallet.md
+++ b/guide/glossary/wallet.md
@@ -41,7 +41,7 @@ A hardware device used to manage a bitcoin wallet. More on the [Hardware overvie
 
 #### Wallet application
 
-A software application used to manage a bitcoin wallet. More on the [Hardware overview]({{ '/guide/getting-started/software/#wallets' | relative_url }}) page.
+A software application used to manage a bitcoin wallet. More on the [Software overview]({{ '/guide/getting-started/software/#wallets' | relative_url }}) page.
 
 #### Non-custodial / Custodial wallet
 


### PR DESCRIPTION
The Wallet application explanation correctly links to the Software overview page, but link says 'Hardware overview'.