### PR TITLE
Added BOLTs to glossary

### DIFF
--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -89,6 +89,10 @@ A standardized technical document format for suggesting improvements to Bitcoin.
 - [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki): *Bech32* standard for native SegWit addresses
 - [BIP174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki): Partially Signed Bitcoin Transaction Format
 
+### BOLT - Basis of Lightning Technology
+
+A standardized technical document format for the Lightning network protocol specifications. They are hosted on Github [here](https://github.com/lightningnetwork/lightning-rfc). The various Lightning implementations must adhere to the BOLTs in order to be interoperable. However, some Lightning implementations may have features which are not defined in BOLTs.
+
 ### Coin control
 
 <div class="center" markdown="1">
@@ -124,7 +128,7 @@ As it is possible to trace the history of coins and see how they were previously
 %}
 
 Allow for combining multiple payments from multiple spenders into a single transaction to make it harder to determine which spender paid which recipient(s). See also [PayJoin](#payjoin-p2ep).
- 
+
  **References:**
 
 - [WabiSabi](https://github.com/zkSNACKs/WabiSabi/blob/master/explainer.md)
@@ -180,7 +184,7 @@ Bitcoin wallets and addresses are have both [public](#public-key) and [private k
 
 ### Lightning Network
 
-The [Lightning Network]({{ 'https://lightning.network' }}) extends Bitcoin with payment channels to increase transaction speed and lower costs. It is becoming widely adopted and accepted as the preferred way to scale Bitcoin. 
+The [Lightning Network]({{ 'https://lightning.network' }}) extends Bitcoin with payment channels to increase transaction speed and lower costs. It is becoming widely adopted and accepted as the preferred way to scale Bitcoin.
 
 ### Miniscript
 


### PR DESCRIPTION
⚡️ [See Deploy Preview](https://deploy-preview-496--sad-borg-390916.netlify.app/guide/glossary/#bolt---basis-of-lightning-technology)

I added BOLTs to the glossary.

I don't feel the need to list out various BOLTs in the same way that we list out various BIPs in the glossary. The reason is because the BOLTs don't always translate into "features" in quite the same way that BIPs do. For example, there is a BOLT for lightning messaging, a BOLT for gossip protocol, a BOLT for DNS bootstrapping -- all very important stuff, but I do not view these as discrete features that are directly relevant to designers.