### PR TITLE
Adds the redirect plugin for when we move pages around

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "minima", "~> 2.5"
 # gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
+  gem 'jekyll-redirect-from'
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-seo-tag"
   gem 'jekyll-compress-images', :git => 'https://github.com/valerijaspasojevic/jekyll-compress-images.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       terminal-table (~> 1.8)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.7.1)
@@ -125,6 +127,7 @@ DEPENDENCIES
   jekyll (~> 4.1.1)
   jekyll-compress-images!
   jekyll-feed (~> 0.12)
+  jekyll-redirect-from
   jekyll-seo-tag
   minima (~> 2.5)
   tzinfo (~> 1.2)

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ twitter_url: "https://twitter.com/bitcoin_design"
 # Build settings
 theme: minima
 plugins:
+  - jekyll-redirect-from
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-compress-images

--- a/guide/designing-products/getting-to-know-your-users.md
+++ b/guide/designing-products/getting-to-know-your-users.md
@@ -5,6 +5,8 @@ description: How best to understand and develop knowledge about your users.
 parent: Designing Bitcoin products
 nav_order: 7
 permalink: /guide/designing-products/getting-to-know-your-users/
+redirect_from:
+ - /guide/onboarding/getting-to-know-your-users/
 main_classes: -no-top-padding
 image: https://bitcoin.design/assets/images/guide/onboarding/getting-to-know-your-users/getting-to-know-your-users-preview.png
 ---


### PR DESCRIPTION
We break URLs when we move or rename pages. This [redirect plug-in](https://github.com/jekyll/jekyll-redirect-from) allows for tracking old URLs per page and creates redirects. An example for the syntax is included from the recent move of "Getting to know your users" in #523.