### PR TITLE
Follow up redirect fix for "First use" page PR

### DIFF
--- a/guide/onboarding/first-use.md
+++ b/guide/onboarding/first-use.md
@@ -5,6 +5,8 @@ description: Common tasks when using a wallet application for the first time.
 parent: Onboarding
 nav_order: 1
 permalink: /guide/onboarding/first-use/
+redirect_from:
+ - /guide/onboarding/creating-a-new-wallet/
 main_classes: -no-top-padding
 image: https://bitcoin.design/assets/images/guide/onboarding/creating-a-new-wallet/creating-a-new-wallet-preview.png
 ---


### PR DESCRIPTION
PR #525 renamed the "Creating a wallet" page to "First use" and changed the URL. For that PR, the Jekyll redirect plugin was not available. Now it is, so here's a fix to ensure old links properly redirect to the new page.