### PR TITLE
Improving contrast in gallery display of images

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -8,7 +8,7 @@ article.guide {
   figure {
     &.-background {
       padding: $spacing-unit/3*2;
-      background-color: #f8f8f8;
+      background-color: #f4f4f4;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -16,7 +16,7 @@ article.guide {
 
     &.-shadow {
       img {
-        filter: drop-shadow(0px 5px 15px rgba(#000000, 0.07));
+        filter: drop-shadow(0px 5px 10px rgba(#000000, 0.1)) drop-shadow(0px 10px 20px rgba(#000000, 0.1));
         border-radius: 10px;
       }
     }


### PR DESCRIPTION
In #537, more Settings screens were added that have a very faint background grey color. This results in super low contrast where the screens almost blends with the background. This tweak makes the gallery background very slightly darker and the box-shadow slightly stronger for better contrast.