### PR TITLE
Tweak Coin Selection page for  ⚡️  Lightning

### DIFF
--- a/guide/payments/coin-selection.md
+++ b/guide/payments/coin-selection.md
@@ -24,9 +24,8 @@ main_classes: -no-top-padding
 
 Coin selection is the process of choosing which [UTXOs](https://bitcoin.design/guide/glossary/#unspent-transaction-output-utxo) (or “coins”) to use as inputs when making an on-chain bitcoin payment. For payments on the Lightning network, coin selection is only relevant for the transaction that opens the lightning channel.
 
-There are two types of coin selection strategies that are used in Bitcoin applications:
-1. [**Automatic Coin Selection**](#automatic-coin-selection) (wallet is delegated to control coin selection on behalf of user)
-2. [**Manual Coin Selection**](#manual-coin-selection-aka-coin-control) (user controls coin selection)
+Coin selection can be [**automatic**](#automatic-coin-selection), and handled by the wallet application. Or it can be [**manual**](#manual-coin-selection-aka-coin-control), letting the user control which coins are used. strategies that are used in Bitcoin applications:
+
 {% include picture.html
    image = "/assets/images/guide/payments/coin-selection/funding-tx.jpg"
    retina = "/assets/images/guide/payments/coin-selection/funding-tx@2x.jpg"

--- a/guide/payments/coin-selection.md
+++ b/guide/payments/coin-selection.md
@@ -24,7 +24,7 @@ main_classes: -no-top-padding
 
 Coin selection is the process of choosing which [UTXOs](https://bitcoin.design/guide/glossary/#unspent-transaction-output-utxo) (or “coins”) to use as inputs when making an on-chain bitcoin payment. For payments on the Lightning network, coin selection is only relevant for the transaction that opens the lightning channel.
 
-Coin selection can be [**automatic**](#automatic-coin-selection), and handled by the wallet application. Or it can be [**manual**](#manual-coin-selection-aka-coin-control), letting the user control which coins are used. strategies that are used in Bitcoin applications:
+Coin selection can be [**automatic**](#automatic-coin-selection), and handled by the wallet application. Or it can be [**manual**](#manual-coin-selection-aka-coin-control), letting the user control which coins are used.
 
 {% include picture.html
    image = "/assets/images/guide/payments/coin-selection/funding-tx.jpg"

--- a/guide/payments/coin-selection.md
+++ b/guide/payments/coin-selection.md
@@ -22,7 +22,7 @@ main_classes: -no-top-padding
 
 # Coin selection
 
-Coin selection is the process of choosing which [UTXOs](https://bitcoin.design/guide/glossary/#unspent-transaction-output-utxo) (or “coins”) to fund a Bitcoin transaction with inputs when making an on-chain payment. Since a wallet contains multiple coins to arrive at a balance, these are retrieved by an algorithm to fulfill the payment amount for outgoing transactions.
+Coin selection is the process of choosing which [UTXOs](https://bitcoin.design/guide/glossary/#unspent-transaction-output-utxo) (or “coins”) to use as inputs when making an on-chain bitcoin payment. For payments on the Lightning network, coin selection is only relevant for the transaction that opens the lightning channel.
 
 There are two types of coin selection strategies that are used in Bitcoin applications:
 1. [**Automatic Coin Selection**](#automatic-coin-selection) (wallet is delegated to control coin selection on behalf of user)


### PR DESCRIPTION
As discussed on #573, very minor tweaks.

- Updates introduction to mention Lightning / Coin selection for transactions that open channels.

Preview: https://deploy-preview-586--sad-borg-390916.netlify.app/guide/payments/send/coin-selection/