### PR TITLE
Deep-link scroll fix

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -219,13 +219,13 @@ article.guide {
   h2, h3,
   .h2, .h3 {
     &::before {
-      height: $spacing-unit * 1;
+      height: $spacing-unit * 3;
+      margin-top: -$spacing-unit * 2;
     }
 
     @include media-query(medium-up) {
       &::before {
-        height: $spacing-unit * 3;
-        margin-top: -$spacing-unit * 2;
+
       }
     }
   }
@@ -233,13 +233,13 @@ article.guide {
   h4, h5, h6,
   .h4, .h5, .h6 {
     &::before {
-      height: $spacing-unit * 1.5;
-      margin-top: -$spacing-unit 1.5;
+      height: $spacing-unit * 3;
+      margin-top: -$spacing-unit * 2;
     }
 
     @include media-query(medium-up) {
       &::before {
-        height: $spacing-unit * 1;
+
       }
     }
   }


### PR DESCRIPTION
Fixes an issue when the deep-linking to a specific header. Previously, the header was covered up by the static nav bar. This adjusts the spacing so the header is visible.

🦸🏼‍♂️ [Check the lovely preview](https://deploy-preview-614--sad-borg-390916.netlify.app/guide/glossary/wallet/#bitcoin-wallet) 💂🏼

Addresses #500.