### PR TITLE
Added more relevant link CTAs to the home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ As Bitcoin’s popularity continues to rise, it is essential that everyone be ab
 
 The Bitcoin Design Community [Slack](http://bitcoindesigners.org) is an open space to discuss and explore everything Bitcoin and design. Open standards are part of our foundation, so all of our work can also be found on [Github](https://github.com/BitcoinDesign).
 
-Everyone is welcome to join and [participate]({{ '/contribute' | relative_url }}).
+Everyone is welcome to join and [participate]({{ '/contribute' | relative_url }}). You can also follow along via our [newsletter](https://bitcoindesign.substack.com), [calendar]({{ '/calendar' | relative_url }}), [Twitter](https://twitter.com/bitcoin_design), [BitcoinTV](https://bitcointv.com/a/bitcoin_design/video-channels) & [YouTube](https://www.youtube.com/c/BitcoinDesign).
 
 ### The Bitcoin Design Guide
 


### PR DESCRIPTION
This is a quick and dirty fix to give more visibility to the newsletter, calendar, Twitter, YouTube and BitcoinTV on the home page. Added links directly to the home page copy.