### PR TITLE
Removed grey background.

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -8,7 +8,7 @@ article.guide {
   figure {
     &.-background {
       padding: $spacing-unit/3*2;
-      background-color: #f4f4f4;
+      background-color: #ffffff;
       display: flex;
       flex-direction: column;
       align-items: center;

--- a/_sass/minima/article/_image-gallery.scss
+++ b/_sass/minima/article/_image-gallery.scss
@@ -2,7 +2,7 @@ article.guide {
   .image-gallery {
     display: flex;
     margin-top: $spacing-unit;
-    background-color: #f8f8f8;
+    background-color: #ffffff;
     justify-content: center;
     max-width: none !important;
 

--- a/_sass/minima/article/_image-slide-gallery.scss
+++ b/_sass/minima/article/_image-slide-gallery.scss
@@ -2,7 +2,7 @@ article.guide {
   .image-slide-gallery {
     margin-top: $spacing-unit;
     margin-bottom: $spacing-unit;
-    background-color: #f8f8f8;
+    background-color: #ffffff;
     justify-content: left;
     max-width: none !important;
     display: flex;


### PR DESCRIPTION
Closes https://github.com/BitcoinDesign/Guide/issues/674

Removes grey backgrounds from .image-gallery. Has a much cleaner look imo.

We will need to go through each UI kit image and remove the grey indent at the top of the image also.