### PR TITLE
Fix for broken retina image

### DIFF
--- a/guide/payments/request.md
+++ b/guide/payments/request.md
@@ -384,7 +384,7 @@ Without Lightning services, a user will need to obtain some inbound liquidity be
 
 {% include picture.html
    image = "/assets/images/guide/onboarding/funding-a-wallet/opening-channel.png"
-   retina = "/assets/images/guide/onboarding/funding-a-wallet/opening-channel@2x.png.png"
+   retina = "/assets/images/guide/onboarding/funding-a-wallet/opening-channel@2x.png"
    layout = "shadow"
    caption = "Using Lightning services, a channel can be opened on-demand if there is no inbound liquidity when a payment is received."
    alt-text = "Screen showing channel being opened."


### PR DESCRIPTION
There is a broken image on [Requesting Bitcoin](https://bitcoin.design/guide/payments/request/#lightning). Issue only affected the retina image, which is probably how it slipped through PR review. Props to Rick on Slack for finding the issue.

[Deploy Preview](https://deploy-preview-681--sad-borg-390916.netlify.app/guide/payments/request/#lightning)