### PR TITLE
Fixing and updating various community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 This is the repository for the [Bitcoin Design Guide](https://bitcoin.design/guide/), and the [bitcoin.design](https://bitcoin.design) community website.
 
-Discussion and collaboration is taking place in the [Bitcoin Design Slack](http://bitcoindesigners.org) (#bitcoin-design-guide).
+Discussion and collaboration is taking place in the [Bitcoin Design Slack](https://join.slack.com/t/bitcoindesign/shared_invite/zt-10sxfovaq-isViijl4RThKRs_TsAQnuA) (#bitcoin-design-guide).
 
 The [Bitcoin Design Guide](https://bitcoin.design/guide/) is a free open-source community resource that helps designers, developers and others working on non-custodial bitcoin-products to create better experiences faster. We hope that, over time, it will cover all relevant types of products, including consumer wallets, merchant interactions, exchanges and more. Better products and experiences should ultimately make it more appealing for anyone to own and use bitcoin.
 
-An equally important goal is that the process of creating this guide nurtures an open-source bitcoin design community that can carry this, and other projects forward longer term. The [Bitcoin Design Slack](http://bitcoindesigners.org) and the [bitcoin.design](https://bitcoin.design) website are the first steps in this direction.
+An equally important goal is that the process of creating this guide nurtures an open-source bitcoin design community that can carry this, and other projects forward longer term. The [Bitcoin Design Slack](https://join.slack.com/t/bitcoindesign/shared_invite/zt-10sxfovaq-isViijl4RThKRs_TsAQnuA) and the [bitcoin.design](https://bitcoin.design) website are the first steps in this direction.
 
 ---
 
 ## Process and how to contribute
 
-The process of creating the guide is meant to be as open and decentralized as possible, resulting in a sustainable model to run projects with the community. Most of the discussion happens in the [Bitcoin Design Slack](http://bitcoindesigners.org), in the #bitcoin-design-guide channel, and here on GitHub in [Issues](https://github.com/BitcoinDesign/Guide/issues), [Pull requests](https://github.com/BitcoinDesign/Guide/pulls) and [Discussions](https://github.com/BitcoinDesign/Guide/discussions). Also see the [roadmap](https://github.com/orgs/BitcoinDesign/projects/2) for an overview of current and upcoming activities.
+The process of creating the guide is meant to be as open and decentralized as possible, resulting in a sustainable model to run projects with the community. Most of the discussion happens in the [Bitcoin Design Slack](https://join.slack.com/t/bitcoindesign/shared_invite/zt-10sxfovaq-isViijl4RThKRs_TsAQnuA), in the #bitcoin-design-guide channel, and here on GitHub in [Issues](https://github.com/BitcoinDesign/Guide/issues), [Pull requests](https://github.com/BitcoinDesign/Guide/pulls) and [Discussions](https://github.com/BitcoinDesign/Guide/discussions). Also see the [roadmap](https://github.com/orgs/BitcoinDesign/projects/2) for an overview of current and upcoming activities.
 
 You can read more about [how to contribute](https://bitcoin.design/guide/contribute/).
 

--- a/calendar.md
+++ b/calendar.md
@@ -45,16 +45,17 @@ Join community calls, design reviews, project discussions and other events. Our 
 
 {% include emoji-box.html
     emoji = "⚡️"
-    title = "Wallet improvement project"
-    description = "Designs review of mobile Lightning wallets. Every 3 weeks on Jitsi."
-    url = "https://github.com/BitcoinDesign/Meta/issues?q=is%3Aissue+is%3Aopen+%22Wallet+improvement%22+"
+    title = "Bitcoin design sprints"
+    description = "Our collaborative design sessions with Lightning wallet projects."
+    url = "https://github.com/BitcoinDesign/Meta/issues/244"
 %}
 
 {% include emoji-box.html
-    emoji = "👀"
-    title = "Design review calls"
-    description = "A project team presents their work and design challenges and we provide feedback. Scheduled as requested."
-    url = "https://github.com/BitcoinDesign/Meta/issues?q=is%3Aissue+is%3Aopen+%22design+review%22+"
+    emoji = "👩🏽‍🎓"
+    title = "Learning bitcoin & design"
+    description = "A series focused on open discussion of the fundamentals."
+    last = true
+    url = "https://github.com/BitcoinDesign/Meta/issues?q=is%3Aissue+Learning+"
 %}
 
 {% include emoji-box.html
@@ -63,6 +64,13 @@ Join community calls, design reviews, project discussions and other events. Our 
     description = "Individual projects organize their own calls to hang out and discuss progress. Peek in if you’re curious."
     last = true
     url = "https://github.com/BitcoinDesign/Meta/issues"
+%}
+
+{% include emoji-box.html
+    emoji = "👀"
+    title = "Design review calls"
+    description = "A project team presents their work and design challenges and we provide feedback. Scheduled as requested."
+    url = "https://github.com/BitcoinDesign/Meta/issues?q=is%3Aissue+is%3Aopen+%22design+review%22+"
 %}
 </div>
 

--- a/contribute.md
+++ b/contribute.md
@@ -42,7 +42,7 @@ If you are not familiar with the concepts of open design, we have a [great intro
 ## How to get involved in projects
 
 1. See the projects we are either involved in or recommend on the [projects]({{ 'projects' | relative_url }}) page
-1. Browse [issues labeled as projects](https://github.com/BitcoinDesign/Meta/issues?q=is%3Aopen+is%3Aissue+label%3Aproject)
+1. Browse [issues labeled as collaborations](https://github.com/BitcoinDesign/Meta/issues?q=is%3Aopen+is%3Aissue+label%3Acollaboration)
 2. Browse the various Slack channels to see what projects are being discussed and chime in. Open-source relies on pro-active contributions.
 1. Contribute to the [Bitcoin Design Guide]({{ '/guide/' | relative_url }})
 

--- a/contribute.md
+++ b/contribute.md
@@ -34,34 +34,27 @@ If you are not familiar with the concepts of open design, we have a [great intro
 
 1. [Join the community on Slack]({{ site.slack_invite_url }}) and say hi in the [#introductions](https://bitcoindesign.slack.com/archives/C0162PV1810) channnel
 1. [Subscribe to the newsletter](https://bitcoindesign.substack.com) and follow on [Twitter](https://twitter.com/bitcoin_design) to stay up-to-date
+1. Subscribe and watch recordings of calls we organized on [BitcoinTV](https://bitcointv.com/a/bitcoin_design/videos) and [YouTube](https://www.youtube.com/c/BitcoinDesign/videos)
 1. Read up on our [project life cycle](https://github.com/BitcoinDesign/Meta/blob/master/Projects.md)
-1. Browse [issues](https://github.com/BitcoinDesign/Meta/issues) for upcoming calls and discussions around processes and coordination
 1. Subscribe to our [calendar]({{ '/calendar/' | relative_url }}) for calls and events we organize
+1. Browse [issues](https://github.com/BitcoinDesign/Meta/issues) for upcoming calls and discussions around process and coordination
 
 ## How to get involved in projects
 
 1. See the projects we are either involved in or recommend on the [projects]({{ 'projects' | relative_url }}) page
 1. Browse [issues labeled as projects](https://github.com/BitcoinDesign/Meta/issues?q=is%3Aopen+is%3Aissue+label%3Aproject)
-2. Browse and post ideas in the [#project-ideas](https://bitcoindesign.slack.com/archives/C0174N5KUF9) Slack channel
-1. Contribute to the [Bitcoin Design Guide](https://github.com/BitcoinDesign/Guide)
+2. Browse the various Slack channels to see what projects are being discussed and chime in. Open-source relies on pro-active contributions.
+1. Contribute to the [Bitcoin Design Guide]({{ '/guide/' | relative_url }})
 
 ## Bitcoin Design Guide
 
+Our first community project is a free, open-source repository for anyone building non-custodial bitcoin products.
+
 - [View the guide]({{ 'guide' | relative_url }})
+- Follow progress on the [roadmap](https://github.com/orgs/BitcoinDesign/projects/2)
 - We have a whole section on [how to contribute]({{ 'guide/contribute/' | relative_url }})
-- Follow progress on the [project board](https://github.com/BitcoinDesign/Guide/projects/1)
 - Discuss on the [#bitcoin-design-guide](https://bitcoindesign.slack.com/archives/C015856BDME) Slack channel
-- Review code and content on the [github repository](https://github.com/BitcoinDesign/Guide)
+- Join a [Design Guide Jam Session](https://github.com/BitcoinDesign/Meta/issues?q=is%3Aissue+is%3Aopen+%22jam+session%22+) where we discuss what is being worked on. We organize them every third Monday
+- Review code and content on the [Github repository](https://github.com/BitcoinDesign/Guide)
 - Read the original [project intro](https://docs.google.com/document/d/1YiYeRIybGmxmErCOI4Jc8Qajz3JGM1JYVfUtpzyCzSk/edit?usp=sharing) document
 - Watch the [How To Contribute to the Bitcoin Design Guide](https://www.youtube.com/playlist?list=PLPZzDjXV0FTZwILz4uyqiJNjUX-kHWP0k) video series
-
-## Further Slack channels
-
-- [#open-design](https://bitcoindesign.slack.com/archives/C015GFYSJNA)
-- [#research](https://bitcoindesign.slack.com/archives/C015DQEPCHJ)
-- [#design-review](https://bitcoindesign.slack.com/archives/C019MTNFKL7)
-- [#art](https://bitcoindesign.slack.com/archives/C0193ED2HT6)
-- [#onboarding](https://bitcoindesign.slack.com/archives/C019PB6GW7M)
-- [#private-key-mgmt](https://bitcoindesign.slack.com/archives/C018RATDW82)
-- [#payments](https://bitcoindesign.slack.com/archives/C0191UWDHBP)
-- [#ux](https://bitcoindesign.slack.com/archives/C016SDP7HT2)

--- a/guide/contribute/contribute.md
+++ b/guide/contribute/contribute.md
@@ -22,7 +22,7 @@ image: https://bitcoin.design/assets/images/guide/contribute/contribute-preview.
 
 # Contribute to the Guide
 
-Join our open community and help us improve the Bitcoin Design Guide. Here’s where you can get involved and contribute.
+Join our open community and help us improve the Bitcoin Design Guide. For a big-picture view of what we are working on right now, see the [roadmap](https://github.com/orgs/BitcoinDesign/projects/2). Here’s where you can get involved and contribute.
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -15,12 +15,16 @@ videoHeight: 840
 
 As bitcoin’s popularity continues to rise, it is essential that everyone be able to participate in this new economy regardless of technical expertise or geography. That can only happen if creators everywhere have the resources and community necessary to foster better bitcoin experiences.
 
-The Bitcoin Design Community [Slack](http://bitcoindesigners.org) is an open space to discuss and explore everything bitcoin and design. Open standards are part of our foundation, so all of our work can also be found on [Github](https://github.com/BitcoinDesign).
+The Bitcoin Design Community [Slack]({{ site.slack_invite_url }}) is an open space to discuss and explore everything bitcoin and design. Open standards are part of our foundation, so all of our work can also be found on [Github](https://github.com/BitcoinDesign).
 
 Everyone is welcome to join and [participate]({{ '/contribute' | relative_url }}). You can also follow along via our [newsletter](https://bitcoindesign.substack.com), [calendar]({{ '/calendar' | relative_url }}), [Twitter](https://twitter.com/bitcoin_design), [BitcoinTV](https://bitcointv.com/a/bitcoin_design/video-channels) & [YouTube](https://www.youtube.com/c/BitcoinDesign).
+
+[Join on Slack]({{ site.slack_invite_url }}){: .button }
 
 ### The Bitcoin Design Guide
 
 Our first community project, the [Bitcoin Design Guide]({{ '/guide' | relative_url }}) is a free, open-source repository for anyone building non-custodial bitcoin products. The guide will eventually cover consumer wallets, merchant interactions, financial applications, and much more.
 
 If you’d like to help by providing feedback, submitting ideas, or creating content, check out the list of current [issues](https://github.com/BitcoinDesign/Guide/issues) or join us on Slack.
+
+[View the guide]({{ '/guide' | relative_url }}){: .button }


### PR DESCRIPTION
I reviewed the home, calendar and contribute pages and saw that there is some outdated info and broken links.

Changes: 
- Replaced the bitcoindesigners.org link as it no longer works (will also get that fixed separately) with our other Slack invite link that works
- Removing Slack channel list from the Contribute page as most of the listed channels have no activity
- Minor link updates on the contribute page (for example, linking to the roadmap project we recently created)
- Adding stronger CTAs to the home page (buttons in addition to the text links we have)
- Revised calendar page with our current call series

If these pages are big entry points for new members, we should ensure to revise them regularly.

Let me know if there are other pages like that that you think need a refresh.