### PR TITLE
Always display sub-sub pages in the sidebar nav

### DIFF
--- a/_includes/secondary-nav.html
+++ b/_includes/secondary-nav.html
@@ -38,9 +38,6 @@
                   {%- if page.url == child.url or page.parent == child.title -%}
                     {%- assign second_level_url = child.url | relative_url -%}
                   {%- endif -%}
-                  {%- if child.has_children -%}
-                    <button class="nav-list-expander" title="Toggle list"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></button>
-                  {%- endif -%}
                   <a href="{{ child.url | relative_url }}" class="nav-list-link{% if page.url == child.url %} -active{% endif %}">{{ child.title }}</a>
                   {%- if child.has_children -%}
                     {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}

--- a/_sass/minima/_nav-list.scss
+++ b/_sass/minima/_nav-list.scss
@@ -19,8 +19,8 @@
     a.nav-list-link {
       display: block;
       font-size: 15px;
-      line-height: 34px;
-      margin-left: 34px;
+      line-height: 30px;
+      margin-left: 30px;
       color: black;
 
       &:visited {
@@ -37,6 +37,10 @@
         }
       }
 
+      &:hover {
+        color: $primary-color;
+      }
+
       &:hover,
       &.-active {
         text-decoration: none;
@@ -49,8 +53,8 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      width: 34px;
-      height: 34px;
+      width: 30px;
+      height: 30px;
       background-color: transparent;
       border-width: 0;
       appearance: none;
@@ -76,10 +80,6 @@
           color: $primary-color;
         }
       }
-
-      & + .nav-list-link {
-
-      }
     }
 
     > .nav-list {
@@ -89,31 +89,36 @@
 
       .nav-list-item {
         position: relative;
+        cursor: pointer;
 
-        .nav-list-link {
-          // color: $primary-color;
+        > .nav-list {
+          display: block;
         }
 
-        .nav-list-expander {
-          // color: $primary-color;
+        > a.nav-list-link {
+          color: #474747;
+
+          &:hover {
+            color: $primary-color;
+          }
         }
       }
     }
 
     &.-active {
       > a.nav-list-link {
-          color: $primary-color;
+        color: $primary-color;
 
-          &:visited {
-            color: $primary-color;
-          }
+        &:visited {
+          color: $primary-color;
+        }
       }
 
       > .nav-list-expander {
-          svg {
-            transform: rotate(90deg);
-            color: $primary-color;
-          }
+        svg {
+          transform: rotate(90deg);
+          color: $primary-color;
+        }
       }
 
       > .nav-list {

--- a/_sass/minima/_site-header.scss
+++ b/_sass/minima/_site-header.scss
@@ -311,6 +311,11 @@
                     }
                 }
 
+                .nav-list-expander {
+                  width: 34px;
+                  height: 34px;
+                }
+
                 .nav-list {
                     button {
                         margin-left: 10px;


### PR DESCRIPTION
Removes the small arrow to expand sub-folders to reduce amount of clicking to be done. Instead, sub-sub pages are always visible. The hierarchy is still clear to viewers through the visual indentation.

Also minor tweaks to the visuals:
- Slightly tighter spacing on desktop
- Very dark grey tone used now for sub-pages instead of black
- Added orange hover state for nav links

One thing I could not figure out is why the cursor is not showing the pointer for sidebar nav links. Should work out of the box, but not sure what is happening here.

This is part of the changed discussed in #551. As it's pretty self-contained, I thought this could be a quick one to get out of the way.