### PR TITLE
Removed extra letter-spacing

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -32,7 +32,6 @@ body {
   min-height: 100vh;
   flex-direction: column;
   overflow-wrap: break-word;
-  letter-spacing: 0.5px;
   width: 100%;
   box-sizing:border-box;
 }


### PR DESCRIPTION
There was 0.5px letter-spacing applied to all text from the original template. Removed it, as the text legibility (IMHO) is better that way.