### PR TITLE
Updated image request template to add some tips

### DIFF
--- a/.github/ISSUE_TEMPLATE/---image-request.md
+++ b/.github/ISSUE_TEMPLATE/---image-request.md
@@ -24,4 +24,11 @@ What kind of visual are you requesting? (Header image, content image, video, pro
 _Add any other context about the request here._
 
 **Illustration guidelines**
+
 If you're a contributor looking to tackle the issue, you can [preview our illustration guidelines](https://bitcoin.design/guide/contribute/illustration-guidelines/).
+
+**Tips**
+
+If you are interested in working on this issue, leave a comment so we can assign it to you.
+
+Please also share your initial ideas and ideally work-in-progress updates before suggesting a final visual. This allows for better collaboration and ensuring the visual goes well with the page content.


### PR DESCRIPTION
It has happened before that creatives responded to an image request with a final image that either didn't go well with the content or was very different than what the request had in mind. To prevent this, we should encourage more communication and collaboration (e.g. start by sharing an idea or concept instead of going straight to a final illustration). This PR adds a tip to the image issue template.