### PR TITLE
Adds Jekyll filter to prevents runts for image captions

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -9,5 +9,5 @@
         	loading="lazy"
     	>
     {% if include.link-url %}</a>{% endif %}
-    {% if include.caption %}<figcaption markdown="1">{{ include.caption | markdownify }}</figcaption>{% endif %}
+    {% if include.caption %}<figcaption markdown="1">{{ include.caption | no_runts | markdownify }}</figcaption>{% endif %}
 </figure>

--- a/_includes/picture.html
+++ b/_includes/picture.html
@@ -38,7 +38,7 @@
 	</picture>
     {% if include.modalImage %}</a>{% endif %}
 	{% if include.caption %}
-        <figcaption markdown="1"{% if include.modalImage %} class="modal-indicator"{% endif %}>{{ include.caption | markdownify }}{% if include.modalImage %}<svg viewBox="0 0 32 32" class="expand-icon"><filter id="shadow"><feDropShadow dx="1" dy="1" stdDeviation="1" flood-opacity="0.3"/></filter><use xlink:href="#svg-expand" style="filter:url('#shadow')" x="4" y="4"></use></svg>{% endif %}</figcaption>
+        <figcaption markdown="1"{% if include.modalImage %} class="modal-indicator"{% endif %}>{{ include.caption | no_runts | markdownify }}{% if include.modalImage %}<svg viewBox="0 0 32 32" class="expand-icon"><filter id="shadow"><feDropShadow dx="1" dy="1" stdDeviation="1" flood-opacity="0.3"/></filter><use xlink:href="#svg-expand" style="filter:url('#shadow')" x="4" y="4"></use></svg>{% endif %}</figcaption>
     {% elsif include.modalImage %}
         <figcaption class="modal-indicator">
             <p>Expand image</p>

--- a/_plugins/no_runts.rb
+++ b/_plugins/no_runts.rb
@@ -1,0 +1,13 @@
+module Jekyll
+  module RuntFilter
+    def no_runts(title)
+      if title.strip.count(" ") >= 2
+        title.split[0...-1].join(" ") + "&nbsp;#{title.split[-1]}"
+      else
+        title.strip
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::RuntFilter)


### PR DESCRIPTION
A very simple method to prevent single words on the last line of image captions. Addresses feedback in [this comment](https://github.com/BitcoinDesign/Guide/pull/739#issuecomment-1088906294) and related to #527 .

👾[Preview](https://deploy-preview-751--sad-borg-390916.netlify.app/guide/daily-spending-wallet/funding/#does-the-user-own-bitcoin)🤖

This would ideally work across all content, but parsing complex text is much more difficult than simple image captions. So I thought we can at least get solve part of this issue with the included plugin.

Code via:
https://stephenhowells.net/prevent-widows-in-jekyll-and-middleman/