### PR TITLE
Adds a "Reference designs" category header to the sidebar

### DIFF
--- a/_includes/secondary-nav.html
+++ b/_includes/secondary-nav.html
@@ -21,6 +21,13 @@
 
       {%- if node.parent == nil and node.title and node.secondary_nav != false -%}
 
+        {%- if node.first_reference_design == true -%}
+
+        <li class="nav-list-divider"></li>
+        <li class="nav-list-category">Reference designs</li>
+
+        {%- endif -%}
+
         <li class="nav-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} -active{% endif %}">
           {%- if page.parent == node.title or page.grand_parent == node.title -%}
             {%- assign first_level_url = node.url | relative_url -%}
@@ -55,6 +62,12 @@
             </ul>
           {%- endif -%}
         </li>
+
+        {%- if node.last_reference_design == true -%}
+
+        <li class="nav-list-divider"></li>
+
+        {%- endif -%}
       {%- endif -%}
 
   {%- endfor -%}

--- a/_sass/minima/_nav-list.scss
+++ b/_sass/minima/_nav-list.scss
@@ -12,6 +12,22 @@
   margin-left: 0;
   list-style: none;
 
+  .nav-list-divider {
+    height: 1px;
+    margin-left: 30px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    background-color: #dedede;
+    box-sizing: border-box;
+  }
+
+  .nav-list-category {
+    padding-left: 30px;
+    font-size: 15px;
+    line-height: 30px;
+    color: #707070;
+  }
+
   .nav-list-item {
     position: relative;
     margin: 0;

--- a/_sass/minima/_site-header.scss
+++ b/_sass/minima/_site-header.scss
@@ -316,6 +316,14 @@
                   height: 34px;
                 }
 
+                .nav-list-divider {
+                    margin-left: 45px;
+                }
+
+                .nav-list-category {
+                    padding-left: 45px;
+                }
+
                 .nav-list {
                     button {
                         margin-left: 10px;

--- a/guide/daily-spending-wallet/landing-page.md
+++ b/guide/daily-spending-wallet/landing-page.md
@@ -6,6 +6,7 @@ nav_order: 4
 has_children: true
 permalink: /guide/daily-spending-wallet/
 main_classes: -no-top-padding
+first_reference_design: true
 image: https://bitcoin.design/assets/images/guide/daily-spending-wallet/daily-spending-preview.jpg
 ---
 

--- a/guide/shared-account.md
+++ b/guide/shared-account.md
@@ -7,6 +7,7 @@ permalink: /guide/shared-account/
 redirect_from:
  - /guide/case-studies/shared-account/
 main_classes: -no-top-padding
+last_reference_design: true
 image: https://bitcoin.design/assets/images/guide/case-studies/shared-account/shared-account-preview.jpg
 image_base: /assets/images/guide/case-studies/shared-account/
 images:


### PR DESCRIPTION
This has been previously discussed and mocked up as part of the [re-org project](https://github.com/BitcoinDesign/Guide/issues/725). Last conversation was [here](https://github.com/BitcoinDesign/Guide/pull/747#issuecomment-1090074709).

This text indicator makes it clear which sections of the guide are reference designs. This structure matches the new landing page as well.

🧑‍🌾[Check out the preview](https://deploy-preview-752--sad-borg-390916.netlify.app/guide/)🧙🏻‍♂️