### PR TITLE
Added note around localization considerations for recovery phrases in the glossary

### DIFF
--- a/guide/daily-spending-wallet/backup-and-recovery/recovery.md
+++ b/guide/daily-spending-wallet/backup-and-recovery/recovery.md
@@ -57,7 +57,7 @@ As outlined earlier in the chapter, we consider an [automatic cloud backup](/gui
 
 ### Restore manually with a recovery phrase
 
-Users may have created a wallet with another wallet application. In this case, they should be able to import that wallet into yours by entering their 12 or 24-word recovery phrase. There are several options for the UI when entering a recovery phase, as outlined earlier in the [manual backup]({{ '/guide/daily-spending-wallet/backup-and-recovery/manual-backup/' | relative_url }}) section of this chapter.
+Users may have created a wallet with another wallet application. In this case, they should be able to import that wallet into yours by entering their 12 or 24-word recovery phrase. There are several options for the UI when entering a recovery phase, as outlined earlier in the [manual backup]({{ '/guide/daily-spending-wallet/backup-and-recovery/manual-backup/' | relative_url }}) section of this chapter. Consider supporting recovery phrases in [multiple languages](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md) for better global accessibility.
 
 ### Restore from an encrypted QR code backup
 

--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -326,7 +326,7 @@ Many wallet-applications work with HD wallets and recovery phrases, and are inte
 
 **Technicalities** - Recovery of multisig-wallets needs both the extended public key and the recovery phrase of all participating keys as well as the master key fingerprint as defined by BIP32 concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. The number of 32 bit unsigned integer indexes must match the depth provided in the extended public key.
 
-**Language considerations** - The recovery phrase consists of English-language words, which may not be intuitive to recognize, remember, or write for many users around the world. If this applies to your user base, it may be more appropriate to use [output descriptors]({{ '/guide/glossary/#output-script-descriptor' | relative_url }}) or other techniques.
+**Language considerations** - Recovery phrases typically consists of English-language words, which may not be intuitive to recognize, remember, or write for many users around the world. Consider supporting multiple languages (see [BIP39 wordlists](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md)), or an alternate backup technique like [output descriptors]({{ '/guide/glossary/#output-script-descriptor' | relative_url }}).
 
 ### Simplified payment verification (SPV)
 

--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -326,6 +326,8 @@ Many wallet-applications work with HD wallets and recovery phrases, and are inte
 
 **Technicalities** - Recovery of multisig-wallets needs both the extended public key and the recovery phrase of all participating keys as well as the master key fingerprint as defined by BIP32 concatenated with the derivation path of the public key. The derivation path is represented as 32-bit little endian unsigned integer indexes concatenated with each other. The number of 32 bit unsigned integer indexes must match the depth provided in the extended public key.
 
+**Language considerations** - The recovery phrase consists of English-language words, which may not be intuitive to recognize, remember, or write for many users around the world. If this applies to your user base, it may be more appropriate to use [output descriptors]({{ '/guide/glossary/#output-script-descriptor' | relative_url }}) or other techniques.
+
 ### Simplified payment verification (SPV)
 
  It is possible to verify bitcoin payments without running a full network node. This is called simplified payment verification, or SPV. A user’s bitcoin spv wallet only needs a copy of the block headers of the longest chain, which are available by querying network nodes until it is apparent that the longest chain has been obtained. SPV lets you validate your transactions without having to worry about anybody else’s transactions. It ensures your transactions are in a block, and it provides confirmations that additional blocks are being added to the chain. An SPV wallet is a type of bitcoin wallet that works this way.

--- a/guide/how-it-works/private-key-management/manual-backup.md
+++ b/guide/how-it-works/private-key-management/manual-backup.md
@@ -79,6 +79,7 @@ Safe backups can be made fairly simple. Take a look at our [bitcoin backups]({{ 
 
 #### Do's
 - Explain what a recovery phrase is, and provide guidance on how to do *safe offline backups* BEFORE the user is exposed to the recovery phrase
+- Consider supporting recovery phrases in [multiple languages](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md) for better global accessibility
 
 #### Products that use this scheme
 


### PR DESCRIPTION
If you're writing Japanese or other languages that are very different from English, then the words in a recovery phrase will look pretty foreign to you (might also have problems typing them back in if you're on a different language keyboard). Muun has gotten this feedback and it was a reason why they were more comfortable using output descriptors.

Not sure if the glossary is the right place for this, but I think it would be good to add this somewhere. Also wonder if we have any recommendations on what to do instead?

🦣[Here's the preview](https://deploy-preview-753--sad-borg-390916.netlify.app/guide/glossary/#recovery-phrase)🐢