### PR TITLE
Renaming case study to reference design in a few remaining places

### DIFF
--- a/guide/daily-spending-wallet/privacy.md
+++ b/guide/daily-spending-wallet/privacy.md
@@ -158,7 +158,7 @@ There is no perfect solution to guarantee 100% privacy that lasts forever becaus
 
 ---
 
-Next, let's dive into the [savings wallet case study]({{ '/guide/savings-wallet/' | relative_url }}).
+Next, let's dive into the [savings wallet reference design]({{ '/guide/savings-wallet/' | relative_url }}).
 
 {% include next-previous.html
    previousUrl = "/guide/daily-spending-wallet/security/"

--- a/guide/designing-products/personal-finance.md
+++ b/guide/designing-products/personal-finance.md
@@ -136,7 +136,7 @@ Bitcoin is different: since the sender must initiate all transactions, automated
 
 The higher-value of these payments necessitates a greater level of security than the daily spending wallet (which is a ["hot wallet"]({{'/guide/glossary/wallet/#hot--cold-wallet' | relative_url}}), meaning that the private key is on a device connected to the internet).
 
-At the moment, a good solution is a desktop application which relies on a hardware device to sign transactions. This reduces the risk of keeping funds on a mobile wallet configuration but adds acceptable friction for transactions that occur less frequently. See the [savings wallet case study]({{ '/guide/savings-wallet/' | relative_url }}) for an exploration of this user experience.
+At the moment, a good solution is a desktop application which relies on a hardware device to sign transactions. This reduces the risk of keeping funds on a mobile wallet configuration but adds acceptable friction for transactions that occur less frequently. See the [savings wallet reference design]({{ '/guide/savings-wallet/' | relative_url }}) for an exploration of this user experience.
 
 A disadvantage to this solution is that it does not use the Lightning network, meaning that the user will need to wait longer for their [transaction to confirm]({{'/guide/how-it-works/transactions/#7-confirmations' | relative_url}}) as well as pay an on-chain transaction fee. However, this will likely not always be the case: in the future, projects such as [Lightning Signer](https://gitlab.com/lightning-signer/docs) may solve this issue by allowing the private keys to be stored separately from the Lightning node on hardware that is security-hardened.
 

--- a/guide/how-it-works/private-key-management/multi-key.md
+++ b/guide/how-it-works/private-key-management/multi-key.md
@@ -42,7 +42,7 @@ All of the previous schemes have relied on a single private key to control the w
 
 This is often called multi-signature, or multisig for short, but is also sometimes referred to as a *vault*. A multi-key setup is described as *n-of-n* to indicate how many keys are needed to sign a transaction out of the issued number. For example, a *2-of-3* setup requires two of the three private keys to sign a transaction for it to be valid.
 
-In the case of a personal wallet, one individual will control all the keys but hold them on different devices for increased security. See the [savings wallet case study]({{ '/guide/savings-wallet/' | relative_url }}) for a UX exploration of this use case.
+In the case of a personal wallet, one individual will control all the keys but hold them on different devices for increased security. See the [savings wallet reference design]({{ '/guide/savings-wallet/' | relative_url }}) for a UX exploration of this use case.
 
 In the case of a shared wallet, different people will control the keys. The number of keys and required co-signers will depend on the use case. With spouses sharing a *joint account*, a simple 1-of-2 multi-key setup might suffice, meaning there are two keys but only one is required to sign for a transaction to be valid. At the other end of the spectrum, a company might require a more complex 3-of-5 setup, requiring three of the five co-signers to approve any transaction.
 

--- a/guide/savings-wallet.md
+++ b/guide/savings-wallet.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Savings wallet
-description: A UX case study for a multi-key bitcoin wallet designed for both daily spending and storing medium amounts.
+description: A UX reference design for a multi-key bitcoin wallet designed for both daily spending and storing medium amounts.
 nav_order: 5
 permalink: /guide/savings-wallet/
 redirect_from:

--- a/guide/shared-account.md
+++ b/guide/shared-account.md
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Shared account
-description: Bitcoin wallet design case study for accounts managed together by multiple owners.
+description: Bitcoin wallet design reference design for accounts managed together by multiple owners.
 nav_order: 7
 permalink: /guide/shared-account/
 redirect_from:
@@ -40,7 +40,7 @@ images:
 
 Editor's notes
 
-Shared account case study.
+Shared account reference design.
 
 Illustration sources
 
@@ -81,7 +81,7 @@ Try the prototype below to see what such a user experience could be like.
    retina = "/assets/images/guide/case-studies/shared-account/case-shared@2x.png"
    mobile = "/assets/images/guide/case-studies/shared-account/case-shared-mobile.png"
    mobileRetina = "/assets/images/guide/case-studies/shared-account/case-shared-mobile@2x.png"
-   alt-text = "Image of case study prototype"
+   alt-text = "Image of reference design prototype"
    width = 800
    height = 500
 %}
@@ -110,7 +110,7 @@ The wireframe screens below show the main onboarding sequence that guides users 
 
 </div>
 
-**Case study resources**
+**Resources**
 - [Protoype](https://www.figma.com/proto/SRWlaxbDulsacpPQn2TTri/Case-study-prototypes?node-id=15%3A824&viewport=333%2C41%2C0.37497082352638245&scaling=scale-down)
 - [Figma design file](https://www.figma.com/file/SRWlaxbDulsacpPQn2TTri/Case-study-prototypes?node-id=15%3A822)
 


### PR DESCRIPTION
Part of our re-org was to rename the case studies to reference designs. We mostly cleaned this up, but missed a few spots that are updated with this PR.

This should complete #622.