### PR TITLE
Minor fix to the no runts plugin

### DIFF
--- a/_plugins/no_runts.rb
+++ b/_plugins/no_runts.rb
@@ -2,7 +2,14 @@ module Jekyll
   module RuntFilter
     def no_runts(title)
       if title.strip.count(" ") >= 2
-        title.split[0...-1].join(" ") + "&nbsp;#{title.split[-1]}"
+        firstPart = title.split[0...-1].join(" ")
+        lastOpen =  firstPart.rindex("<")
+
+        if lastOpen
+          title.strip
+        else
+          title.split[0...-1].join(" ") + "&nbsp;#{title.split[-1]}"
+        end
       else
         title.strip
       end


### PR DESCRIPTION
Does not insert non-breaking spaces if the text contains a "<". Should fix the issue for now. Someone with better Ruby knowledge could probably create a much more complete version of this.

Addresses #771.