### PR TITLE
Added info on bLIP-0011 NameDesc

### DIFF
--- a/guide/daily-spending-wallet/requesting.md
+++ b/guide/daily-spending-wallet/requesting.md
@@ -195,7 +195,7 @@ This meta data should also be able to be [backed up]({{ "/guide/onboarding/backi
 
 #### Add a requester name with NameDesc
 
-You can also convey the name of the user requesting the payment. For example, suppose the user is able to define their name in the settings of their wallet app. The app could then append the user's name to the beginning of the description field in a BOLT11 invoice. For example, if Alice makes an invoice with a memo that says "For design work", then the description in the BOLT11 invoice would become:
+You can convey the name of the user requesting the payment. Suppose the user is able to define their name in the settings of their wallet app. The app could then append the user's name to the beginning of the description field in a BOLT11 invoice. For example, if Alice makes an invoice with a memo that says "For design work", then the description in the BOLT11 invoice would become:
 
 ```
 Alice:  For design work

--- a/guide/daily-spending-wallet/requesting.md
+++ b/guide/daily-spending-wallet/requesting.md
@@ -201,7 +201,7 @@ You can convey the name of the user requesting the payment. Suppose the user is 
 Alice:  For design work
 ```
 
-This description is human-readable, but wallets that support [bLIP-0011 NameDesc](https://github.com/lightning/blips/pull/11/) will parse this as a name and a description.
+This description is human-readable, and wallets that support [bLIP-0011 NameDesc](https://github.com/lightning/blips/pull/11/) will parse this as a name and a description.
 
 </div>
 

--- a/guide/daily-spending-wallet/requesting.md
+++ b/guide/daily-spending-wallet/requesting.md
@@ -173,7 +173,7 @@ More on the [address types]({{ "/guide/glossary/address/" | relative_url }}) and
 
 </div>
 
-### Meta data
+### Metadata
 
 A payment request with only standard data, like an amount and date, communicates little to both parties about purpose and context of the payment.
 
@@ -183,15 +183,15 @@ A payment request with only standard data, like an amount and date, communicates
    image = "/assets/images/guide/daily-spending-wallet/requesting/single-use-payment-request-settings.png"
    retina = "/assets/images/guide/daily-spending-wallet/requesting/single-use-payment-request-settings@2x.png"
    layout = "float-left-desktop -background -shadow"
-   caption = "Let users attach payment meta data to single-use payment requests."
+   caption = "Let users attach payment metadata to single-use payment requests."
    alt-text = "Screen showing single payment request settings."
    width = 250
    height = 541
 %}
 
-Users should have the option to attach a note for record-keeping and for the sender to read, tags, labels and any other meta data that may be relevant to give more context to the payment.
+Users should have the option to attach a note for record-keeping and for the sender to read, tags, labels and any other metadata that may be relevant to give more context to the payment.
 
-This meta data should also be able to be [backed up]({{ "/guide/onboarding/backing-up-a-wallet/" | relative_url }}) in case the user loses access to their wallet and has to restore it.
+This metadata should also be able to be [backed up]({{ "/guide/onboarding/backing-up-a-wallet/" | relative_url }}) in case the user loses access to their wallet and has to restore it.
 
 #### Add a requester name with NameDesc
 

--- a/guide/daily-spending-wallet/requesting.md
+++ b/guide/daily-spending-wallet/requesting.md
@@ -189,9 +189,19 @@ A payment request with only standard data, like an amount and date, communicates
    height = 541
 %}
 
-Users should have the option to attach a note for record-keeping and for the sender to read, tags, labels and any other metadata that may be relevant to give more context to the payment.
+Users should have the option to attach a note for record-keeping and for the sender to read, tags, labels and any other meta data that may be relevant to give more context to the payment.
 
 This meta data should also be able to be [backed up]({{ "/guide/onboarding/backing-up-a-wallet/" | relative_url }}) in case the user loses access to their wallet and has to restore it.
+
+#### Add a requester name with NameDesc
+
+You can also convey the name of the user requesting the payment. For example, suppose the user is able to define their name in the settings of their wallet app. The app could then append the user's name to the beginning of the description field in a BOLT11 invoice. For example, if Alice makes an invoice with a memo that says "For design work", then the description in the BOLT11 invoice would become:
+
+```
+Alice:  For design work
+```
+
+This description is human-readable, but wallets that support [bLIP-0011 NameDesc](https://github.com/lightning/blips/pull/11/) will parse this as a name and a description.
 
 </div>
 


### PR DESCRIPTION
[NameDesc](https://github.com/lightning/blips/pull/11/) is an interesting feature we've talked about in Slack. I have added a little mention of this feature in the metadata section of the Requesting page. It seems like a recommendation that ranges from harmless to helpful. Supporting wallets will parse the description as a name and a memo, and non-supporting wallets will display a human readable description string.

💻 [Deploy Preview](https://deploy-preview-774--sad-borg-390916.netlify.app/guide/daily-spending-wallet/requesting/#meta-data)