### PR TITLE
Add notes about community association

### DIFF
--- a/guide/resources/design-files.md
+++ b/guide/resources/design-files.md
@@ -46,7 +46,7 @@ files:
     retina: /assets/images/guide/resources/design-files/slide-template@2x.jpg
     width: 400
     height: 210
-  - caption: <a href="https://www.figma.com/community/file/1040606190770628557/Bitcoin-Design-Community-seal">Bitcoin Design Community seal</a><br/><a href="/assets/images/guide/resources/design-files/bitcoin-design-community.zip" download>Download images</a>
+  - caption: <a href="https://www.figma.com/community/file/1040606190770628557/Bitcoin-Design-Community-seal">Bitcoin Design Community seal</a><br/><a href="/assets/images/guide/resources/design-files/bitcoin-design-community.zip" download>Download images</a><br/><a href="#community-seal-usage">Usage note</a>
     alt: Bitcoin Design Community seal
     image: /assets/images/guide/resources/design-files/bitcoin-design-community-seal.jpg
     retina: /assets/images/guide/resources/design-files/bitcoin-design-community-seal@2x.jpg
@@ -121,6 +121,12 @@ Sequences of interactive screens can often be more effectively evaluated through
 ### Inspecting
 
 The right-hand panel has an “Inspect” tab that is a great companion for development. Clicking any element will reveal layout and style information under this tab. More on [Figma for developers](https://www.figma.com/best-practices/tips-on-developer-handoff/an-overview-of-figma-for-developers/).
+
+---
+
+## Community seal usage
+
+Feel free to use and remix the seal. Before attaching it more formally to a project or initiative, be sure to ask the broader community. Not everyone might be OK with it. You can post in the [#general](https://bitcoindesign.slack.com/archives/C014J9ZKXB4) channel in Slack or open an issue in the [meta repo](https://github.com/BitcoinDesign/Meta/issues) on github.
 
 ---
 

--- a/projects.md
+++ b/projects.md
@@ -169,11 +169,11 @@ https://www.figma.com/file/qr4P17z6WSPADm6oW0cKw2/?node-id=612%3A5994
 
 We don't just chat about design. We also actively improve design in the bitcoin ecosystem. Projects launched by community members often focus on creating design resources.
 
-With collaborations, we try to help other bitcoin projects improve their products' design and user experience. For more details, see our [Collaboration](https://github.com/BitcoinDesign/Meta/blob/master/Collaboration.md) and [Project](https://github.com/BitcoinDesign/Meta/blob/master/Projects.md) documents. If you are interested in getting involved, reach out directly to the projects below, or reach out in our [Slack]({{ site.slack_invite_url }}).
+With collaborations, some of us try to help other bitcoin projects improve their products' design and user experience. For more details, see our [Collaboration](https://github.com/BitcoinDesign/Meta/blob/master/Collaboration.md) and [Project](https://github.com/BitcoinDesign/Meta/blob/master/Projects.md) documents. If you are interested in getting involved, reach out directly to the projects below, or reach out in our [Slack]({{ site.slack_invite_url }}).
 
 ## Community projects
 
-These are design projects we have initiated ourselves.
+These are some of the design projects we have initiated ourselves.
 
 <div class="project-grid">
 {% for item in page.projects %}
@@ -194,7 +194,7 @@ These are design projects we have initiated ourselves.
 
 ## Collaborations
 
-For a full list of current and past collaborations, see our [collaboration board](https://github.com/BitcoinDesign/Meta/projects/2).
+For a more complete list of current and past collaborations, see our [collaboration board](https://github.com/BitcoinDesign/Meta/projects/2).
 
 <div class="project-grid">
 {% for item in page.collaborations %}
@@ -212,3 +212,7 @@ For a full list of current and past collaborations, see our [collaboration board
       </div>
 {% endfor %}
 </div>
+
+#### Adding a project or collaboration
+
+The Bitcoin Design Community is intentionally only loosely organized. This makes it difficult to define specific rules of what is a community effort and what isn't. Best approach is to get consensus by asking in the [#general](https://bitcoindesign.slack.com/archives/C014J9ZKXB4) channel in Slack or opening an issue in the [meta repo](https://github.com/BitcoinDesign/Meta/issues) on Github.


### PR DESCRIPTION
Added a "usage note" to the community seal link/download on the [Design files page](https://deploy-preview-810--sad-borg-390916.netlify.app/guide/resources/design-files/). The note asks the reader to get consensus before associating the seal with a project more formally.

Second addition is a note on the [Projects page](https://deploy-preview-810--sad-borg-390916.netlify.app/projects/#adding-a-project-or-collaboration) about adding projects/collaborations. It points out that lines are a bit blurry and it's best to ask and get consensus.

This is a response to a discussion around the community being referenced as author/authority in formal settings, as well as what makes a community effort and what doesn't. This is tricky because the community is a pretty loosely organized group and not a formal entity. As with other things, a good approach is (IMHO) to avoid strict rules and rely on the wisdom of the crowd (consensus). These changes are intended to encourage that mutual exchange.

Preview links are in the text above.