### PR TITLE
Removed runts from image galleries

### DIFF
--- a/_includes/image-gallery.html
+++ b/_includes/image-gallery.html
@@ -4,7 +4,7 @@
 
 {% capture imageURL %}{{ page.image_base }}{{ item.file }}.png{% endcapture %}
 {% capture imageURLRetina %}{{ page.image_base }}{{ item.file }}@2x.png{% endcapture %}
-{% capture captionText %}{{ item.caption | markdownify }}{% endcapture %}
+{% capture captionText %}{{ item.caption | no_runts | markdownify }}{% endcapture %}
 
 {% include picture.html
    image = imageURL

--- a/_plugins/no_runts.rb
+++ b/_plugins/no_runts.rb
@@ -1,17 +1,21 @@
 module Jekyll
   module RuntFilter
     def no_runts(title)
-      if title.strip.count(" ") >= 2
-        firstPart = title.split[0...-1].join(" ")
-        lastOpen =  firstPart.rindex("<")
+      if(title)
+        if title.strip.count(" ") >= 2
+          firstPart = title.split[0...-1].join(" ")
+          lastOpen =  firstPart.rindex("<")
 
-        if lastOpen
-          title.strip
+          if lastOpen
+            title.strip
+          else
+            title.split[0...-1].join(" ") + "&nbsp;#{title.split[-1]}"
+          end
         else
-          title.split[0...-1].join(" ") + "&nbsp;#{title.split[-1]}"
+          title.strip
         end
       else
-        title.strip
+        title
       end
     end
   end


### PR DESCRIPTION
Applied the "no runts" to the image gallery include. Require a minor fix to the plugin itself so it doesn't break when a null value is passed in.

For context, the "no runts" plugin replaces regular spaces with non-breaking spaces between the last two words of a piece of text. This prevents the effect of having a single word in the last line of a paragraph (aka a runt).