### PR TITLE
A11y text color contrast fix

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -26,7 +26,7 @@ article.guide {
     display: inline-block;
     padding: 0 $spacing-unit/3*2;
     border-radius: 3px;
-    color: white;
+    color: black;
     line-height: 43px;
     text-decoration: none;
     background-color: $primary-color;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -20,7 +20,7 @@ dl, dd, ol, ul, figure {
  */
 body {
   font: $base-font-weight #{$base-font-size}/#{$base-line-height} $base-font-family;
-  color: rgba(var(--front), 0.72);
+  color: var(--front);
   background-color: $background-color;
   -webkit-text-size-adjust: 100%;
   -webkit-font-feature-settings: "kern" 1;
@@ -142,6 +142,18 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: $heavy-font-weight;
   line-height: 1.4;
   color: var(--frontHex);
+
+  a {
+    color: $link-base-color-lg;
+
+    &:visited {
+      color: $link-visited-color-lg;
+    }
+
+    &:hover {
+      color: $link-hover-color-lg;
+    }
+  }
 }
 
 h1 {
@@ -156,6 +168,10 @@ a {
   color: $link-base-color;
   text-decoration: none;
   transition: color 100ms $ease;
+
+  @media(prefers-contrast: more) {
+    text-decoration: underline;
+  }
 
   &:visited {
     color: $link-visited-color;

--- a/_sass/minima/_nav-list.scss
+++ b/_sass/minima/_nav-list.scss
@@ -45,16 +45,16 @@
 
       &.-active {
         font-weight: 500;
-        color: $primary-color;
+        color: $link-base-color;
         text-decoration: none;
 
         &:visited {
-          color: $primary-color;
+          color: $link-visited-color;
         }
       }
 
       &:hover {
-        color: $primary-color;
+        color: $link-hover-color;
       }
 
       &:hover,
@@ -115,7 +115,7 @@
           color: #474747;
 
           &:hover {
-            color: $primary-color;
+            color: $link-hover-color;
           }
         }
       }
@@ -123,17 +123,17 @@
 
     &.-active {
       > a.nav-list-link {
-        color: $primary-color;
+        color: $link-base-color;
 
         &:visited {
-          color: $primary-color;
+          color: $link-base-color;
         }
       }
 
       > .nav-list-expander {
         svg {
           transform: rotate(90deg);
-          color: $primary-color;
+          color: $link-base-color;
         }
       }
 

--- a/_sass/minima/_site-header.scss
+++ b/_sass/minima/_site-header.scss
@@ -51,11 +51,11 @@
             }
 
             &:hover {
-                color: $primary-color;
+                color: $link-hover-color-lg;
                 text-decoration: none;
 
                 svg {
-                    color: $primary-color;
+                    color: $link-hover-color-lg;
                 }
             }
         }
@@ -71,12 +71,12 @@
                 font-weight: 500;
 
                 &:hover {
-                    color: $primary-color;
+                    color: $link-hover-color;
                     text-decoration: none;
                 }
 
                 &.active {
-                    color: $primary-color;
+                    color: $link-base-color;
                 }
             }
 
@@ -109,13 +109,13 @@
 
             &:hover {
                 svg {
-                    color: $primary-color;
+                    color: $link-hover-color-lg;
                 }
             }
 
             &.-active {
                 svg {
-                    color: $primary-color;
+                    color: $link-base-color-lg;
                 }
             }
         }
@@ -214,7 +214,7 @@
                             background-color: rgba($primary-color, 0.05);
 
                             h3 {
-                                color: $primary-color;
+                                color: $link-hover-color-lg;
                             }
                         }
                     }
@@ -265,7 +265,7 @@
                 }
 
                 &:hover {
-                    color: $primary-color;
+                    color: $link-hover-color;
                 }
             }
 
@@ -345,7 +345,7 @@
                     height: calc(100vh - 60px);
                 }
 
-                .nav-trigger {                    
+                .nav-trigger {
                     svg {
                         fill: $primary-color;
                     }

--- a/_sass/minima/skins/classic.scss
+++ b/_sass/minima/skins/classic.scss
@@ -10,9 +10,12 @@ $text-color:            #000000 !default;
 $background-color:      #ffffff !default;
 $code-background-color: #f9f9f9 !default;
 
-$link-base-color:       $primary-color !default;
+$link-base-color:       #AF6408 !default;
 $link-visited-color:    darken($link-base-color, 5%) !default;
 $link-hover-color:      lighten($link-base-color, 5%) !default;
+$link-base-color-lg:    #DB7900 !default;
+$link-visited-color-lg: darken($link-base-color-lg, 1%) !default;
+$link-hover-color-lg:   lighten($link-base-color-lg, 5%) !default;
 
 $border-color-01:       #f3f3f3 !default;
 $border-color-02:       lighten($brand-color, 50%) !default;


### PR DESCRIPTION
This PR _potentially_ closes #831. I reworked colors across the site to improve contrast for our a11y push. I just wanted to try this so we could see what it would look like and evaluate the right approach.

- I sought to meet WCAG AA. As I understand it, most websites should strive for this. WCAG AAA has very strict requirements, which would be good to meet if you are building a product meant to be used specifically for visual handicaps. But for our purposes, I think WCAG AA is sufficient. Correct me if I'm wrong on that.
- Body text - I made this `#000000` throughout. I don't think the subtle gray is that noticeable to most folks, and it doesn't help the links contrast at all by having the text non-black.
- Normal sized links (less than 24px) - these are now `#AF6408`. [See the test result](https://webaim.org/resources/linkcontrastchecker/?fcolor=000000&bcolor=FFFFFF&lcolor=AF6408).
- Large sized links (18px+ and bold, or 24px+ and regular) are now `#DB7900`. [See the test result](https://webaim.org/resources/contrastchecker/?fcolor=DB7900&bcolor=FFFFFF).
  - We can use a brighter orange for the large size text because the contrast ratio requirements are not as strict.
  - I am ignoring the link color contrast checker for large links and instead using the generic contrast checker. Rationale: the link color contrast checker is specifically designed for links in body text. Page headings and navbars don't apply, if my understanding is correct.
- Buttons now use `#000000` for text color. This allows us to maintain the nice bright `#F7931A ` background color while having a strong 9.14:1 contrast ratio. [See the test result](https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=F7931A).
  - Again, I used the generic contrast checker because buttons are not body text.

Notice the perfect score the ARC provides for color contrast.

### Before

![Screen Shot 2022-05-27 at 4 31 09 PM](https://user-images.githubusercontent.com/2414177/170785429-b1622e6f-47af-40ab-a7a6-092923b021a8.png)

### After

![Screen Shot 2022-05-27 at 4 30 04 PM](https://user-images.githubusercontent.com/2414177/170785302-ace19451-3615-422c-86b4-7d531fdcbae9.png)