### PR TITLE
Add sitemap Jekyll plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :jekyll_plugins do
   gem "jekyll-seo-tag"
   gem 'jekyll-compress-images', :git => 'https://github.com/valerijaspasojevic/jekyll-compress-images.git'
   gem 'html-proofer'
+  gem 'jekyll-sitemap'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.7.1)
       jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -129,6 +131,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.12)
   jekyll-redirect-from
   jekyll-seo-tag
+  jekyll-sitemap
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data
@@ -136,4 +139,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.15
+   2.2.26

--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ plugins:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-compress-images
+  - jekyll-sitemap
 
 imageoptim:
   allow_lossy: true


### PR DESCRIPTION
Closes https://github.com/BitcoinDesign/Guide/issues/839 

This plugin automatically generates a `sitemap.xml` file that contains all of the pages of bitcoin.design when running `bundle exec jekyll build`. This helps with SEO of the site. 

Will be creating a sitemap.md file that is a more visual version of this auto generated sitemap.xml file (the xml file is primarily for search engine crawlers) in a follow up PR. 

We may also want to use https://www.npmjs.com/package/netlify-plugin-submit-sitemap/v/0.3.0 alongside this so the sitemap is automatically sent to major search engines when Netlify builds and deploys the site so new pages get indexed quicker. 