### PR TITLE
Updated bLIP-011 NameDesc link

### DIFF
--- a/guide/daily-spending-wallet/requesting.md
+++ b/guide/daily-spending-wallet/requesting.md
@@ -201,7 +201,7 @@ You can convey the name of the user requesting the payment. Suppose the user is 
 Alice:  For design work
 ```
 
-This description is human-readable, and wallets that support [bLIP-0011 NameDesc](https://github.com/lightning/blips/pull/11/) will parse this as a name and a description.
+This description is human-readable, and wallets that support [bLIP-0011 NameDesc](https://github.com/lightning/blips/blob/master/blip-0011.md) will parse this as a name and a description.
 
 </div>
 


### PR DESCRIPTION
Now that BLIP-011 has been merged, we can link directly to the BLIP instead of the PR.