### PR TITLE
Update homepage title

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,6 +4,8 @@
 
 layout: home
 permalink: /
+title: Bitcoin Design. Open-source design for bitcoin products.
+description: Bitcoin Design is a free open-source community resource that helps designers and developers working on bitcoin-products to create better experiences, faster.
 video: /assets/images/bitcoin-design-preview.mp4
 videoType: 'video/mp4'
 videoWidth: 1600
@@ -11,7 +13,6 @@ videoHeight: 840
 ---
 
 ## We are helping make [bitcoin](https://bitcoin.org) more intuitive and accessible.
-
 
 As bitcoin’s popularity continues to rise, it is essential that everyone be able to participate in this new economy regardless of technical expertise or geography. That can only happen if creators everywhere have the resources and community necessary to foster better bitcoin experiences.
 


### PR DESCRIPTION
Closes https://github.com/BitcoinDesign/Guide/issues/838

The [jekyll-seo-tag](https://github.com/jekyll/jekyll-seo-tag) plugin is great but there is circumstances where it doesn't represent search results as well as they should be such as the home page (see image below). We should get into the habit of checking pages in Google and updating the `title:` and `description:` front matter if they aren't being represented clearly. 

![image](https://user-images.githubusercontent.com/55287964/173993535-14b3a948-6ddd-48be-be71-a519f59b0a18.png)
