### PR TITLE
Formatting page fixes

### DIFF
--- a/_sass/minima/article/_do.scss
+++ b/_sass/minima/article/_do.scss
@@ -5,6 +5,8 @@ article.guide {
     flex-wrap: wrap;
     background-color: #f8f8f8;
     @include responsive('padding', 20, 30);
+    align-items: center;
+    align-content: flex-start;
 
     .icon {
       flex-grow: 0;

--- a/guide/contribute/formatting/index.md
+++ b/guide/contribute/formatting/index.md
@@ -499,8 +499,8 @@ Provide clear error messages that tell users how to solve the problem.
 Write overly complex error messages that require deep technical knowledge.
 
 {% include image.html
-   image = "/assets/images/guide/contribute/formatting/example-image-square.jpg"
-   retina = "/assets/images/guide/contribute/formatting/example-image-square@2x.jpg"
+   image = "/assets/images/guide/contribute/formatting/media/example-image-square.jpg"
+   retina = "/assets/images/guide/contribute/formatting/media/example-image-square@2x.jpg"
    alt-text = "Example image"
    width = 400
    height = 400
@@ -515,8 +515,8 @@ Write overly complex error messages that require deep technical knowledge.
 Provide clear error messages that tell users how to solve the problem.
 
 {% include image.html
-   image = "/assets/images/guide/contribute/formatting/example-image-square.jpg"
-   retina = "/assets/images/guide/contribute/formatting/example-image-square@2x.jpg"
+   image = "/assets/images/guide/contribute/formatting/media/example-image-square.jpg"
+   retina = "/assets/images/guide/contribute/formatting/media/example-image-square@2x.jpg"
    alt-text = "Example image"
    width = 400
    height = 400
@@ -527,8 +527,8 @@ Provide clear error messages that tell users how to solve the problem.
 Write overly complex error messages that require deep technical knowledge.
 
 {% include image.html
-   image = "/assets/images/guide/contribute/formatting/example-image-square.jpg"
-   retina = "/assets/images/guide/contribute/formatting/example-image-square@2x.jpg"
+   image = "/assets/images/guide/contribute/formatting/media/example-image-square.jpg"
+   retina = "/assets/images/guide/contribute/formatting/media/example-image-square@2x.jpg"
    alt-text = "Example image"
    width = 400
    height = 400


### PR DESCRIPTION
2 fixes for Formatting page.

- Broken image introduced in #879
- "Do/Don't" titles can fall out of alighnment with it's respective icon when the adjacent column's text is longer.