### PR TITLE
Add links to new mnemonics research

### DIFF
--- a/guide/designing-products/accessibility.md
+++ b/guide/designing-products/accessibility.md
@@ -149,6 +149,7 @@ The accessibility pages by [Apple](https://www.apple.com/accessibility/), [Micro
 - [Material design accessibility tips](https://material.io/design/usability/accessibility.html#understanding-accessibility)
 - [Web content accessibility guidelines (WCAG) 2.0](https://www.w3.org/TR/WCAG20/)
 - [Accessibility guidelines for non-web applications (WCAG2ICT)](https://www.w3.org/TR/wcag2ict/)
+- Securing recovery phrases in braille via [New mnemonics](https://medium.com/@thorbjoernkoenig/new-mnemonics-48f00b8bb68)
 
 ### Usability testing resources
 

--- a/guide/how-it-works/private-key-management/manual-backup.md
+++ b/guide/how-it-works/private-key-management/manual-backup.md
@@ -65,6 +65,12 @@ Safe backups can be made fairly simple. Take a look at our [bitcoin backups]({{ 
 
 {% include fact/close.html %}
 
+{% include tip/open.html color="blue" label="You can be creative" icon="info" %}
+
+Humans have many ways of memorizing and decoding information, from braille to sound and visual patterns, and beyond. Recovery phrases do not have to be secured as written words on paper. For more on this, see [New mnemoics](https://medium.com/@thorbjoernkoenig/new-mnemonics-48f00b8bb68).
+
+{% include tip/close.html %}
+
 ### Best practice
 
 #### When to use

--- a/guide/how-it-works/private-key-management/manual-backup.md
+++ b/guide/how-it-works/private-key-management/manual-backup.md
@@ -92,6 +92,10 @@ Most bitcoin wallets, including:
 - [Coinbase Wallet](https://wallet.coinbase.com)
 - [Rise](https://www.risewallet.com)
 
+#### Resources
+
+- Unique approaches to storing recovery phrases via [New mnemonics](https://medium.com/@thorbjoernkoenig/new-mnemonics-48f00b8bb68)
+
 ---
 
 Next, let's look at [external signers]({{ '/guide/how-it-works/private-key-management/external-signers/' | relative_url }}).

--- a/guide/resources/design-research.md
+++ b/guide/resources/design-research.md
@@ -97,6 +97,12 @@ A survey and follow-up interview of 990 bitcoin users to determine bitcoin manag
 
 ## Independent research
 
+#### [New Mnemonics](https://medium.com/@thorbjoernkoenig/new-mnemonics-48f00b8bb68)
+
+_2022 by Thorbjoern Koenig._
+
+An exploration of new approaches to securing mnemonics ([recovery phrases]({{ '/guide/glossary/#recovery-phrase' | relative_url }})) based on the unique capabilities of our bains and different personality types.
+
 #### [The State of Lightning Volume 2](https://arcane.no/research/reports/the-state-of-lightning-volume-2)
 
 _Login required to access. 2022 by Arcane research._


### PR DESCRIPTION
Adding links to Thor's [New mnemonics](https://medium.com/@thorbjoernkoenig/new-mnemonics-48f00b8bb68) research.

Pages updated (links are previews with changes):
- [Accessibility](https://deploy-preview-900--bitcoin-design-site.netlify.app/guide/designing-products/accessibility/#sources-of-information) (tip at center and resources at the bottom of the page)
- Private key management -> [Manual backup](https://deploy-preview-900--bitcoin-design-site.netlify.app/guide/how-it-works/private-key-management/manual-backup/#resources) (resources at the bottom of the page)
- Resources -> [Design research](https://deploy-preview-900--bitcoin-design-site.netlify.app/guide/resources/design-research/#new-mnemonics) (link & short summary)

This PR only adds links at the moment. It would be cool if we could include a bit more. Could be a direct quote from the research, or an appeal somewhere to be creative when thinking about solutions and give New mnemonics as an example. I'll come back to this, let me know if you have a good idea.