### PR TITLE
Fix capitalization

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -26,7 +26,7 @@ Illustration sources
 
 -->
 
-# The Bitcoin design guide
+# The bitcoin design guide
 
 **Bitcoin is a global payment protocol that anyone with Internet access can participate in and contribute to. However, because bitcoin’s use cases are as vast as its user base, building bitcoin applications can be complicated.**
 


### PR DESCRIPTION
I couldn't find it explicitly said anywhere in the design guide itself, but I saw [on Twitter](https://twitter.com/nwoodfine/status/1491096859112542208) that the design guide uses little-b "bitcoin" everywhere now and afaict that is the case, except for in this spot (maybe elsewhere too but I couldn't find with a quick scan).

Alternatively, this heading could be "The Bitcoin Design Guide" (title-cased), but I erred on the side of sentence-casing it since "design guide" is already lower-cased and I figured this was intentional.