### PR TITLE
List Challenge 6: Private purchase

### DIFF
--- a/guide/resources/design-challenges.md
+++ b/guide/resources/design-challenges.md
@@ -57,6 +57,12 @@ Bob has been gifted a $100 bitcoin gift card for his birthday and wants to redee
 
 Bob Jr wants to receive his weekly allowance in bitcoin. Design a low-fidelity app with flows that lets him share a [request]({{ '/guide/daily-spending-wallet/requesting/#sharing-the-request' | relative_url }}) for allowance with his parents, who may or may not have a bitcoin wallet.
 
+## Challenge 6: Private purchase
+
+Bob wants to buy an engagement ring to surprise Alice. He has to pay on-chain because it's a large expense. Alice recently sent him sats, so she has a view into the sats in Bob's wallet. Design a low-fidelity flow Bob might follow to spend his sats using [PayJoin](https://en.bitcoin.it/wiki/PayJoin). In contrast to a naïve transaction, thanks to PayJoin, even if Alice sees the resulting transaction on-chain she won't be able to discern whether it is a small transfer, output consolidation, or the large purchase that would spoil the surprise.
+
+[Get started with these design-oriented notes](https://docs.google.com/document/d/1y5qiKEX2WXMoDgdNclKcZ2RHDIM8wX5OkhREA-Hmc0k/edit?usp=sharing). For more details, check out the bitcoin design [call](https://bitcointv.com/w/3cZH5KVZwsxU6X9iNzDkBE), [FigJam File with in-call notes](https://www.figma.com/file/YC1rjRo3xYvkqJPL4vlg4r/Learning-Bitcoin-and-Design---PayJoins?node-id=0%3A1&t=I3u9Sbe7iMp6WbjV-1), mention this challenge in [slack](https://join.slack.com/t/bitcoindesign/shared_invite/zt-10sxfovaq-isViijl4RThKRs_TsAQnuA) or email d at ngould dot dev for help.
+
 ## Tips
 
 It is completely up to you to decide how you want to go about each challenge. If you’d like a few starting points, we gathered some tips for you:

--- a/guide/resources/design-challenges.md
+++ b/guide/resources/design-challenges.md
@@ -61,7 +61,7 @@ Bob Jr wants to receive his weekly allowance in bitcoin. Design a low-fidelity a
 
 Bob wants to buy an engagement ring to surprise Alice. He has to pay on-chain because it's a large expense. Alice recently sent him sats, so she has a view into the sats in Bob's wallet. Design a low-fidelity flow Bob might follow to spend his sats using [PayJoin](https://en.bitcoin.it/wiki/PayJoin). In contrast to a naïve transaction, thanks to PayJoin, even if Alice sees the resulting transaction on-chain she won't be able to discern whether it is a small transfer, output consolidation, or the large purchase that would spoil the surprise.
 
-[Get started with these design-oriented notes](https://docs.google.com/document/d/1y5qiKEX2WXMoDgdNclKcZ2RHDIM8wX5OkhREA-Hmc0k/edit?usp=sharing). For more details, check out the bitcoin design [call](https://bitcointv.com/w/3cZH5KVZwsxU6X9iNzDkBE), [FigJam File with in-call notes](https://www.figma.com/file/YC1rjRo3xYvkqJPL4vlg4r/Learning-Bitcoin-and-Design---PayJoins?node-id=0%3A1&t=I3u9Sbe7iMp6WbjV-1), mention this challenge in [slack](https://join.slack.com/t/bitcoindesign/shared_invite/zt-10sxfovaq-isViijl4RThKRs_TsAQnuA) or email d at ngould dot dev for help.
+[Get started with these design-oriented notes](https://docs.google.com/document/d/1y5qiKEX2WXMoDgdNclKcZ2RHDIM8wX5OkhREA-Hmc0k/edit?usp=sharing). For more details, check out the bitcoin design [call](https://bitcointv.com/w/3cZH5KVZwsxU6X9iNzDkBE), [FigJam File with in-call notes](https://www.figma.com/file/YC1rjRo3xYvkqJPL4vlg4r/Learning-Bitcoin-and-Design---PayJoins?node-id=0%3A1&t=I3u9Sbe7iMp6WbjV-1), mention this challenge in [slack]({{ site.slack_invite_url }}) or email d at ngould dot dev for help.
 
 ## Tips
 


### PR DESCRIPTION
This challenge intends to add an avenue to get involved with PayJoin adoption. Does the challenge included in the commit exemplify a plausible scenario that is compelling to solve?

Thanks to @sbddesign for the suggestion in the https://github.com/BitcoinDesign/Meta/issues/419 discussion and @johnsBeharry for always digging deeper and suggesting specific software to add PayJoin to.

Separately, do these challenges have go-to owners? If I were picking up a challenge, or a GitHub issue, I might want to start by asking the author or reviewer some questions straight away.

