### PR TITLE
Adding more Nostr relays to post to

### DIFF
--- a/.well-known/nostr.json
+++ b/.well-known/nostr.json
@@ -11,6 +11,7 @@
       "wss://nostr.bitcoiner.social",
       "wss://nostr.onsats.org",
       "wss://nostr.orangepill.dev",
+      "wss://nostr.zebedee.cloud",
       "wss://relay.current.fyi",
       "wss://relay.damus.io",
       "wss://relay.nostr.info",

--- a/.well-known/nostr.json
+++ b/.well-known/nostr.json
@@ -6,12 +6,9 @@
     "8c29b321d0f3c61343882ea49623e84771690cd0566e40b90f08e5d34336aaa0": [
       "wss://brb.io",
       "wss://eden.nostr.land",
-      "wss://jiggytom.ddns.net",
       "wss://nos.lol",
       "wss://nostr-pub.wellorder.net",
       "wss://nostr.bitcoiner.social",
-      "wss://nostr.fmt.wiz.biz",
-      "wss://nostr.ono.re",
       "wss://nostr.onsats.org",
       "wss://nostr.orangepill.dev",
       "wss://relay.current.fyi",

--- a/.well-known/nostr.json
+++ b/.well-known/nostr.json
@@ -4,11 +4,23 @@
   },
   "relays": {
     "8c29b321d0f3c61343882ea49623e84771690cd0566e40b90f08e5d34336aaa0": [
-      "wss://relay.snort.social",
-      "wss://relay.damus.io",
       "wss://brb.io",
+      "wss://eden.nostr.land",
+      "wss://jiggytom.ddns.net",
+      "wss://nos.lol",
+      "wss://nostr-pub.wellorder.net",
+      "wss://nostr.bitcoiner.social",
+      "wss://nostr.fmt.wiz.biz",
+      "wss://nostr.ono.re",
+      "wss://nostr.onsats.org",
+      "wss://nostr.orangepill.dev",
+      "wss://relay.current.fyi",
+      "wss://relay.damus.io",
       "wss://relay.nostr.info",
-      "wss://nostr.zebedee.cloud"
+      "wss://relay.snort.social"
     ]
   }
 }
+
+
+


### PR DESCRIPTION
There has been feedback that the community profile did not load. I'm adding more relays to the account that the profile and posts will be pushed to. These are the default relays that Damus, Astral.ninja and Snort connect to. I removed a few after checking [nostr.watch](http://nostr.watch) and seeing that some were not reachable or had super low uptime (e.g. 4%).

Overall, the community could should have pretty broad reach across relays, so members can subscribe easily and don't have to seek out specific relays (or get confused because nothing loads).

As the Nostr network matures, I assume it will become a bit more clear as to how to distribute content across relays. For now, this broad coverage option seems like a good approach. But feel free to let me know your thoughts, I'm also curious to learn more about this topic.

[nostr.json preview](https://deploy-preview-983--bitcoin-design-site.netlify.app/.well-known/nostr.json)