### PR TITLE
Added "Fiat" to Glossary.

### DIFF
--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -206,6 +206,10 @@ Same as xpub, however the y denotes that this xpub belongs to a wallet that is f
 
 Same as ypub though the z denotes it is an extended public key from a segregated witness enabled wallet following [BIP84](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki).
 
+### Fiat
+
+Fiat money is a type of currency that is issued and backed by a government. It has value because the government says it does, and people are willing to accept it as payment for goods and services. Examples of fiat money include the US dollar, Indian rupees, the euro, and the Japanese yen. Unlike physical commodities like gold, silver or copper, fiat money is not backed by a physical commodity and its value is not directly tied to the value of a commodity. Instead, it is based on trust in the issuing government and its ability to maintain a stable currency. To learn more, visit [Wikipedia](https://en.wikipedia.org/wiki/Fiat_money).
+
 ### Gap limit
 
 For performance reasons, on-chain wallets generally only create 20 addresses and watch them for incoming transactions. As addresses are used, new ones are generated and watched. As only 20 consecutive unused addresses are being watched, incoming transactions on the 21st address and beyond will not be detected. This may cause problems for users when importing wallets. For more, see [BIP 44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Address_gap_limit) and [this article](https://blog.lopp.net/mind-the-bitcoin-address-gap/).

--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -208,7 +208,7 @@ Same as ypub though the z denotes it is an extended public key from a segregated
 
 ### Fiat
 
-Fiat money is a type of currency that is issued and backed by a government. It has value because the government says it does, and people are willing to accept it as payment for goods and services. Examples of fiat money include the US dollar, Indian rupees, the euro, and the Japanese yen. Unlike physical commodities like gold, silver or copper, fiat money is not backed by a physical commodity and its value is not directly tied to the value of a commodity. Instead, it is based on trust in the issuing government and its ability to maintain a stable currency. To learn more, visit [Wikipedia](https://en.wikipedia.org/wiki/Fiat_money).
+Fiat money is a type of legal tender that is issued by a government. The value of fiat money is not backed by, or tied to a commodity such as gold, silver or copper, instead it is derived from the relationship between supply and demand and the stability of the issuing government. Examples of fiat money include the US dollar, Indian rupees, the euro, and the Japanese yen. To learn more, visit [Wikipedia](https://en.wikipedia.org/wiki/Fiat_money).
 
 ### Gap limit
 


### PR DESCRIPTION
Closes #975 

I have worked on the above-mentioned issue and have added the definition of "fiat" currency in the glossary. I have also linked a Wikipedia page where the user can learn more about fiat and fiat currencies if he wishes to.

Let me know if there is any more addition or improvement needed from my side.

Screenshot :

![image](https://user-images.githubusercontent.com/94376674/218483358-815fac5a-a93c-4685-b116-2d37d592b74a.png)
