### PR TITLE
Updated Slack invite link (old one expired)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ twitter_username: jekyllrb
 github_username:  jekyll
 
 github_repository_url: "https://github.com/BitcoinDesign/Guide/"
-slack_invite_url: "https://join.slack.com/t/bitcoindesign/shared_invite/zt-10sxfovaq-isViijl4RThKRs_TsAQnuA"
+slack_invite_url: "https://join.slack.com/t/bitcoindesign/shared_invite/zt-1rxp55chx-dH6pWlTtWBqRw7VztgvBGA"
 youtube_url: "https://www.youtube.com/c/BitcoinDesign"
 twitter_url: "https://twitter.com/bitcoin_design"
 


### PR DESCRIPTION
After seeing people in the Summer of Bitcoin Discord complain about the invite link not working, I tested it and saw it is no longer valid. This PR adds a new one (limit of 400 people, no time expiry).