### PR TITLE
Update address example

### DIFF
--- a/guide/glossary/address.md
+++ b/guide/glossary/address.md
@@ -53,7 +53,7 @@ Benefits of Taproot include the ability to use Schnorr Signatures, offering bett
 
 Taproot addresses start with `bc1p` and are case insensitive.
 
-Example: `bc1pmzfrwwndsqmk5yh69yjr5lfgfg4ev8c0tsc06e`
+Example: `bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297`
 
 ### SegWit address - [P2WPKH](https://en.bitcoin.it/wiki/Bech32)
 


### PR DESCRIPTION
Fixed Taproot address example. Taproot addresses are bigger in length than SegWit, previous example had same length

ref: https://blog.trezor.io/bitcoin-addresses-and-how-to-use-them-35e7312098ff