### PR TITLE
Describe PSBT as portable data format

### DIFF
--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -409,11 +409,12 @@ A transaction is a transfer of value over the bitcoin network. While transaction
 An output that has not been sent to another address. The bitcoin wallet balance is calculated from adding up unspent outputs.
 
 ###  Partially signed bitcoin transaction (PSBT)
-A file format for bitcoin transactions that are not fully signed yet. Allows for passing around a transaction to other applications or devices for signing, for example in a multi-signature wallet setup.
+A portable transaction data format that enables discrete participants to contribute to a single transaction. For example, psbt fascilitates contribution from both software and hardware wallet in multi-signature and between the sender and recipient of a payjoin.
 
 **References:**
 
 - [BIP174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki): Partially Signed Bitcoin Transaction Format
+- [BIP370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki): PSBT Version 2
 
 
 ###  Passphrase

--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -409,7 +409,8 @@ A transaction is a transfer of value over the bitcoin network. While transaction
 An output that has not been sent to another address. The bitcoin wallet balance is calculated from adding up unspent outputs.
 
 ###  Partially signed bitcoin transaction (PSBT)
-A portable transaction data format that enables discrete participants to contribute to a single transaction. For example, psbt fascilitates contribution from both software and hardware wallet in multi-signature and between the sender and recipient of a payjoin.
+
+A portable data format for transactions before they are verified by the network. Often, the same application constructs the transaction and signs it. But there are applications where this is not the case, like when using a [hardware wallet](https://bitcoin.design/guide/glossary/#wallet), [multisig](https://bitcoin.design/guide/glossary/#multi-signature-wallet-multisig) or [payjoin](https://bitcoin.design/guide/glossary/#payjoin-p2ep). Parties to these applications share transaction data by communicating PSBTs.
 
 **References:**
 

--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -416,7 +416,7 @@ A portable data format for transactions before they are verified by the network.
 
 - [BIP174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki): Partially Signed Bitcoin Transaction Format
 - [BIP370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki): PSBT Version 2
-
+- [PSBT Versions Deep Dive](https://chaincase.app/words/interactive-transactions-psbt)
 
 ###  Passphrase
 A passphrase can be added to the [recovery phrase](#recovery-phrase) for extra security.

--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -410,7 +410,7 @@ An output that has not been sent to another address. The bitcoin wallet balance 
 
 ###  Partially signed bitcoin transaction (PSBT)
 
-A portable data format for transactions before they are verified by the network. Often, the same application constructs the transaction and signs it. But there are applications where this is not the case, like when using a [hardware wallet](https://bitcoin.design/guide/glossary/#wallet), [multisig](https://bitcoin.design/guide/glossary/#multi-signature-wallet-multisig) or [payjoin](https://bitcoin.design/guide/glossary/#payjoin-p2ep). Parties to these applications share transaction data by communicating PSBTs.
+A portable data format for transactions before they are verified by the network. Often, the same application constructs the transaction and signs it. But there are applications where this is not the case, like when using a [hardware wallet]({{ '/guide/glossary/#wallet' | relative_url }}), [multisig]({{ '/guide/glossary/#multi-signature-wallet-multisig' | relative_url }}) or [payjoin]({{ '/guide/glossary/#payjoin-p2ep' | relative_url }}). Parties to these applications share transaction data by communicating PSBTs.
 
 **References:**
 


### PR DESCRIPTION
Yes, PSBT was born to solve the multisig problem, but now, especially after PSBT2, its use has expanded to facilitate all types of interactive transactions.

I'd rather see it described as a data format or a bitcoin standard than a file format. The situations where psbt are serialized to a file system represent only a fraction of their use.

It may help to explain that, in contrast to PSBT, a consensus Transaction only has data necessary to perform validation, including only references to look up to inputs earlier in the blockchain. While a PSBT may have complete input information rather than just those reference pointers.

I see PSBTs as scaffolding with which interactive parties may come to agree on a consensus transaction to broadcast.