### PR TITLE
Fixes next-previous navigation on the Savings wallet page

### DIFF
--- a/guide/savings-wallet.md
+++ b/guide/savings-wallet.md
@@ -264,8 +264,8 @@ Daily and per-transaction spending limits are a unique aspect of this applicatio
 ---
 
 {% include next-previous.html
-   previousUrl = "/guide/daily-spending-wallet/privacy/"
-   previousName = "Privacy"
+   previousUrl = "/guide/daily-spending-wallet/settings/"
+   previousName = "Settings"
    nextUrl = "/guide/upgradeable-wallet/"
    nextName = "Upgradeable wallet"
 %}


### PR DESCRIPTION
Micro-PR. I was reading the Savings wallet page in the guide after our jam session today, when I noticed this:

<img width="726" alt="Screenshot 2023-04-11 at 09 56 26" src="https://user-images.githubusercontent.com/114083781/231196695-bb7d19b5-193c-48c2-b232-a0e57e562ce9.png">

The page previous to Savings wallet is Settings, but the navigation links to the Privacy page before that. Hope it is okay to open a PR for this.