### PR TITLE
Implements prefers-contrast media query

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -29,21 +29,21 @@ article.guide {
     color: white;
     line-height: 43px;
     text-decoration: none;
-    background-color: $primary-color;
+    background-color: var(--link-base-color);
     transition: all 150ms $ease;
 
     &:hover {
-      background-color: darken($primary-color, 5);
+      background-color: var(--link-hover-color);
     }
 
     &.-outline {
       background-color: transparent;
-      color: $primary-color;
-      border: 1px solid $primary-color;
+      color: var(--link-base-color);
+      border: 1px solid var(--link-base-color);
 
       &:hover {
-        color: darken($primary-color, 5);
-        border-color: darken($primary-color, 5);
+        color: var(--link-hover-color);
+        border-color: var(--link-hover-color);
       }
     }
   }
@@ -133,7 +133,7 @@ article.guide {
 
     &:hover {
       .small-video-link__caption {
-        color: $primary-color;
+        color: var(--primary-color);
       }
 
       .small-video-link__image {
@@ -212,7 +212,7 @@ article.guide {
         transition: all 100ms $ease;
 
         &:hover {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
 

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -71,7 +71,7 @@ main {
 
 a:focus-visible,
 button:focus-visible {
-  outline: 4px solid rgba($primary-color, 0.6);
+  outline: 4px solid rgba(var(--primary-color-rgb), 0.6);
   outline-offset: 1px;
 }
 
@@ -157,16 +157,16 @@ h1 {
  * Links
  */
 a {
-  color: $link-base-color;
+  color: var(--link-base-color);
   text-decoration: none;
   transition: color 100ms $ease;
 
   &:visited {
-    color: $link-visited-color;
+    color: var(--link-visited-color);
   }
 
   &:hover {
-    color: $link-hover-color;
+    color: var(--link-hover-color);
     text-decoration: underline;
   }
 

--- a/_sass/minima/_glossary-page.scss
+++ b/_sass/minima/_glossary-page.scss
@@ -14,7 +14,7 @@
                 color: rgba(var(--front), 0.72);
 
                 &:hover {
-                    color: $primary-color;
+                    color: var(--primary-color);
                     text-decoration: none;
                 }
             }

--- a/_sass/minima/_home-banner.scss
+++ b/_sass/minima/_home-banner.scss
@@ -202,7 +202,7 @@
         text-decoration: underline;
 
         &:hover {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
     }
@@ -222,7 +222,7 @@
         text-decoration: underline;
 
         &:hover {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
 

--- a/_sass/minima/_nav-list.scss
+++ b/_sass/minima/_nav-list.scss
@@ -45,16 +45,16 @@
 
       &.-active {
         font-weight: 500;
-        color: $primary-color;
+        color: var(--primary-color);
         text-decoration: none;
 
         &:visited {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
 
       &:hover {
-        color: $primary-color;
+        color: var(--primary-color);
       }
 
       &:hover,
@@ -77,21 +77,21 @@
       svg {
         width: 15px;
         height: 15px;
-        color: $link-base-color;
+        color: var(--link-base-color);
         transition: all 150ms $ease;
       }
 
       &:active,
       &:focus {
         border-width: 0;
-        background-color: rgba($primary-color, 0.1);
+        background-color: rgba(var(--primary-color-rgb), 0.1);
       }
 
       &:hover {
-        background-color: rgba($primary-color, 0.1);
+        background-color: rgba(var(--primary-color-rgb), 0.1);
 
         svg {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
     }
@@ -113,7 +113,7 @@
           color: #474747;
 
           &:hover {
-            color: $primary-color;
+            color: var(--primary-color);
           }
         }
       }
@@ -121,17 +121,17 @@
 
     &.-active {
       > a.nav-list-link {
-        color: $primary-color;
+        color: var(--primary-color);
 
         &:visited {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
 
       > .nav-list-expander {
         svg {
           transform: rotate(90deg);
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
 

--- a/_sass/minima/_next-previous.scss
+++ b/_sass/minima/_next-previous.scss
@@ -21,7 +21,7 @@
       transition: all 150ms $ease;
 
       &:hover {
-        color: $primary-color;
+        color: var(--primary-color);
         text-decoration: underline;
       }
     }
@@ -67,11 +67,11 @@
         }
 
         &:hover {
-          color: $primary-color;
+          color: var(--primary-color);
           text-decoration: none;
 
           svg {
-            fill: $primary-color !important;
+            fill: var(--primary-color) !important;
           }
         }
 
@@ -119,8 +119,8 @@
     }
 
     &:hover {
-      color: $primary-color;
-      border-color: $primary-color;
+      color: var(--primary-color);
+      border-color: var(--primary-color);
     }
   }
 

--- a/_sass/minima/_search-page.scss
+++ b/_sass/minima/_search-page.scss
@@ -24,7 +24,7 @@
 
         &:active,
         &:focus {
-            border-color: $primary-color;
+            border-color: var(--primary-color);
             outline: none;
         }
     }
@@ -60,10 +60,10 @@
 
             &:hover {
                 text-decoration: none;
-                background-color: rgba($primary-color, 0.05);
+                background-color: rgba(var(--primary-color-rgb), 0.05);
 
                 h3 {
-                    color: $primary-color;
+                    color: var(--primary-color);
                 }
             }
         }

--- a/_sass/minima/_site-footer.scss
+++ b/_sass/minima/_site-footer.scss
@@ -31,7 +31,7 @@
 
       &:hover {
         svg {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
     }
@@ -51,7 +51,7 @@
         font-size: 16px;
 
         &:hover {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
     }
@@ -74,7 +74,7 @@
 
         &:hover {
           svg {
-            fill: $primary-color !important;
+            fill: var(--primary-color) !important;
           }
         }
 
@@ -101,7 +101,7 @@
         font-size: 16px;
 
         &:hover {
-          color: $primary-color;
+          color: var(--primary-color);
         }
       }
 

--- a/_sass/minima/_site-header.scss
+++ b/_sass/minima/_site-header.scss
@@ -32,7 +32,7 @@
             white-space: nowrap;
 
             &:focus {
-                outline: 2px solid $primary-color;
+                outline: 2px solid var(--primary-color);
             }
 
             svg {
@@ -51,15 +51,15 @@
             }
 
             &:focus {
-                background-color: rgba($primary-color, 0.05);
+                background-color: rgba(var(--primary-color), 0.05);
             }
 
             &:hover {
-                color: $primary-color;
+                color: var(--primary-color);
                 text-decoration: none;
 
                 svg {
-                    color: $primary-color;
+                    color: var(--primary-color);
                 }
             }
         }
@@ -75,16 +75,16 @@
                 font-weight: 500;
 
                 &:hover {
-                    color: $primary-color;
+                    color: var(--primary-color);
                     text-decoration: none;
                 }
 
                 &:focus {
-                    background-color: rgba($primary-color, 0.1);
+                    background-color: rgba(var(--primary-color), 0.1);
                 }
 
                 &.active {
-                    color: $primary-color;
+                    color: var(--primary-color);
                 }
             }
 
@@ -110,18 +110,18 @@
             }
 
             &:focus {
-                background-color: rgba($primary-color, 0.05);
+                background-color: rgba(var(--primary-color), 0.05);
             }
 
             &:hover {
                 svg {
-                    color: $primary-color;
+                    color: var(--primary-color);
                 }
             }
 
             &.-active {
                 svg {
-                    color: $primary-color;
+                    color: var(--primary-color);
                 }
             }
         }
@@ -205,10 +205,10 @@
 
                         &:hover {
                             text-decoration: none;
-                            background-color: rgba($primary-color, 0.05);
+                            background-color: rgba(var(--primary-color), 0.05);
 
                             h3 {
-                                color: $primary-color;
+                                color: var(--primary-color);
                             }
                         }
                     }
@@ -255,11 +255,11 @@
                 }
 
                 &:focus {
-                    background-color: rgba($primary-color, 0.05);
+                    background-color: rgba(var(--primary-color), 0.05);
                 }
 
                 &:hover {
-                    color: $primary-color;
+                    color: var(--primary-color);
                 }
             }
 
@@ -341,7 +341,7 @@
 
                 .nav-trigger {                    
                     svg {
-                        fill: $primary-color;
+                        fill: var(--primary-color);
                     }
                 }
             }
@@ -376,7 +376,7 @@
                         bottom: -1px;
                         height: 1px;
                         opacity: 0;
-                        background-color: $primary-color;
+                        background-color: var(--primary-color);
                     }
 
                     &.active {

--- a/_sass/minima/_variables.scss
+++ b/_sass/minima/_variables.scss
@@ -52,12 +52,12 @@ $primary-color: $bitcoin-yellow;
   --link-visited-color: hsl(var(--primary-color-h), var(--primary-color-s), var(--primary-color-l-darker));
 
   @media (prefers-contrast: more) {
-    --primary-color: #DB821A;
-    --primary-color-rgb: 219, 130, 26;
-    --primary-color-h: 32;
-    --primary-color-s: 79%;
-    --primary-color-l: 48%;
-    --primary-color-l-darker: 38%;
+    --primary-color: #9c5c19;
+    --primary-color-rgb: 156, 92, 25;
+    --primary-color-h: 31;
+    --primary-color-s: 72%;
+    --primary-color-l: 35%;
+    --primary-color-l-darker: 25%;
   }
 }
 

--- a/_sass/minima/_variables.scss
+++ b/_sass/minima/_variables.scss
@@ -25,19 +25,13 @@ $small_width:              640px;
 $large_width:              1024px;
 $huge_width:               1440px;
 
-
-
-
-
 $yellow: #FFF75C;
 $bitcoin-yellow: #F7931A;
+$bitcoin-yellow-contrast: #DB821A;
 $blue: #6490E3;
 $green: #6FCF97;
 $red: #DE5E57;
 $primary-color: $bitcoin-yellow;
-
-
-
 
 :root {
   --back: 251, 251, 251;
@@ -45,6 +39,26 @@ $primary-color: $bitcoin-yellow;
 
   --backHex: #fbfbfb;
   --frontHex: #000000;
+
+  --primary-color: #F7931A;
+  --primary-color-rgb: 247, 147, 26;
+  --primary-color-h: 33;
+  --primary-color-s: 93%;
+  --primary-color-l: 54%;
+  --primary-color-l-darker: 44%;
+
+  --link-base-color: var(--primary-color);
+  --link-hover-color: hsl(var(--primary-color-h), var(--primary-color-s), var(--primary-color-l-darker));
+  --link-visited-color: hsl(var(--primary-color-h), var(--primary-color-s), var(--primary-color-l-darker));
+
+  @media (prefers-contrast: more) {
+    --primary-color: #DB821A;
+    --primary-color-rgb: 219, 130, 26;
+    --primary-color-h: 32;
+    --primary-color-s: 79%;
+    --primary-color-l: 48%;
+    --primary-color-l-darker: 38%;
+  }
 }
 
 .theme--dark {

--- a/_sass/minima/article/_emoji-box.scss
+++ b/_sass/minima/article/_emoji-box.scss
@@ -35,7 +35,7 @@ article.guide {
 
             .emoji-box__copy {
                 h5 {
-                    color: $primary-color;
+                    color: var(--primary-color);
                 }
             }
         }

--- a/_sass/minima/skins/classic.scss
+++ b/_sass/minima/skins/classic.scss
@@ -24,7 +24,6 @@ $table-header-bg-color: lighten($brand-color, 95%) !default;
 $table-header-border:   lighten($brand-color, 90%) !default;
 $table-border-color:    $border-color-01 !default;
 
-
 // Syntax highlighting styles should be adjusted appropriately for every "skin"
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This allows users to enable increased contrast in the accessibility settings of their operating system, and see that reflected in the website.

🍗[Check the preview](https://deploy-preview-1015--bitcoin-design-site.netlify.app)🌽

This is also a proof-of-concept for implementing this using CSS variables. It requires replacing $ variables (like $primary-color) with [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) (var(--primary-color), and using [hsl](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl) to calculate darker colors on the fly. Benefit is that the CSS variables can dynamically change at runtime (not just during build time). This more dynamic system allows for the [prefers-contrast](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast) color change to only require 8 lines of code. This needs some testing to ensure it all works cross-browser.

The high contrast orange color (a darker version of the regular one) was chosen via [this site](https://www.myndex.com/APCA/) to get a passing score at 18px font size for both orange-on-white and white-on-orange. I did not touch any grays or other colors in this PR yet.

Regular view:

<img width="1342" alt="image" src="https://github.com/BitcoinDesign/Guide/assets/695901/4005c985-a224-40d9-8440-3dd1d1f1474c">

 With increased contrast enabled (via the OS):

<img width="1341" alt="image" src="https://github.com/BitcoinDesign/Guide/assets/695901/d524f463-1531-4c8e-aa97-333f1450b3cb">

And here's the toggle to switch in the MacOS accessibility settings:

![image](https://github.com/BitcoinDesign/Guide/assets/695901/b45747c4-2363-4f77-a437-91e013ca4f23)

You may wonder why the primary color is defined as hex, RGB, and HSL. Reason is that different CSS color functions require different formats (`rgba()` wants `rgb`, `hsl()` needs `hsl` values). 

This may address our unresolved conversation in #831.
