### PR TITLE
Add a link to the survey in the contribute section

### DIFF
--- a/guide/contribute/propose-a-change.md
+++ b/guide/contribute/propose-a-change.md
@@ -50,6 +50,7 @@ If you're looking to help, but not sure where to begin:
 - Check issues labeled as [Design](https://github.com/BitcoinDesign/Guide/issues?q=is%3Aissue+is%3Aopen+label%3Adesign)
 - Consult the community [on Discord]({{ site.discord_invite_url }}) or start a [GitHub discussion](https://github.com/BitcoinDesign/Guide/discussions/new) with your proposal
 - Browse [bitcoin.design](https://bitcoin.design/guide) test it and try to identify issues yourself
+- Review [the survey](https://github.com/BitcoinDesign/Meta/issues/320) we did on the guide and think of ways to address the feedback
 
 For more challenging pieces of work, a new page, or a new chapter, it's a good idea to talk to the community and seek consensus before you begin working on it. This helps avoid work duplication and ensures your efforts are aligned with the community-determined goals.
 


### PR DESCRIPTION
We did a survey on how people use the design guide, and Mo put together a great presentation on it. I'm adding a link in the contribute section for reference, right where we give people tips on finding ways to improve the guide. Then we can close the GitHub issue for the survey, as discussed in the comments.

[Check the preview](https://deploy-preview-1017--bitcoin-design-site.netlify.app/guide/contribute/propose-a-change/#identifying-what-to-fix)

See: https://github.com/BitcoinDesign/Meta/issues/320