### PR TITLE
Minor copy tweaks to visual language & user research

### DIFF
--- a/guide/designing-products/user-research.md
+++ b/guide/designing-products/user-research.md
@@ -206,7 +206,7 @@ Links to:
 
 ---
 
-Join the discussion in the [#research channel](https://discord.com/channels/903125802726596648/903126614236360764) on the Bitcoin Design Discord.
+For practical guidance, use the [Bitcoin UX Research Toolkit](https://bitcoinresearch.xyz) and join the discussion in the [#research channel](https://discord.com/channels/903125802726596648/903126614236360764) on the Bitcoin Design Discord.
 
 <!--
 
@@ -216,8 +216,6 @@ Links to:
 -->
 
 ---
-
-Frameworks are helpful tools to organize user behavior. Our next section introduces one with a focus on the .
 
 Next we will look at why it is important to [get to know your users]({{ '/guide/designing-products/getting-to-know-your-users/' | relative_url }}) when designing bitcoin applications.
 

--- a/guide/getting-started/visual-language.md
+++ b/guide/getting-started/visual-language.md
@@ -54,7 +54,7 @@ Since bitcoin answers to no central authority, there is no single symbol or logo
    layout = "float-left"
 %}
 
-Satoshi Nakamoto created this lettered golden coin for the original Bitcoin Core client, [released on January 9, 2009](https://web.archive.org/web/20140326174921/http://www.mail-archive.com/cryptography@metzdowd.com/msg10142.html).
+Satoshi Nakamoto created this lettered golden coin for the original Bitcoin client, [released on January 9, 2009](https://web.archive.org/web/20140326174921/http://www.mail-archive.com/cryptography@metzdowd.com/msg10142.html).
 
 </div>
 


### PR DESCRIPTION
Addressing an issue brought up on Twitter on the Visual language page, described in #1044.
[Preview the changes](https://deploy-preview-1046--bitcoin-design-site.netlify.app/guide/getting-started/visual-language/#original-symbol)

Removing an incomplete and unnecessary sentence on the User research page, and adding a link to the Bitcoin UX Research Kit (contextually relevant, and someone said it's hard to find the project).
[Preview the changes](https://deploy-preview-1046--bitcoin-design-site.netlify.app/guide/designing-products/user-research/#resources)