### PR TITLE
Adds info about transcripts to the calendar page

### DIFF
--- a/calendar.md
+++ b/calendar.md
@@ -93,3 +93,7 @@ Add our [calendar](https://raw.githubusercontent.com/BitcoinDesign/Meta/calendar
 - A maintainer needs to add the `call` label to the issue (this prevents spam)
 - The calendar auto-updates whenever a new issue is created, or an existing issue is edited
 - If you `Watch` the [BitcoinDesign/Meta repo](https://github.com/BitcoinDesign/Meta), you will also get emails when new events are created
+
+### Transcripts
+
+Transcripts of some calls are available at [btctranscripts.com](https://btctranscripts.com/bitcoin-design/). You can contribute to both creating transcripts via an [automated script](https://github.com/bitcointranscripts/tstbtc), and to [reviewing them](https://review.btctranscripts.com/).


### PR DESCRIPTION
It's a bit hidden at the bottom of the page, but at least we have some info. Transcripts should also be directly linked to from each video description, so there is not a huge reliance on this specific piece of text.

🫠[Check the preview](https://deploy-preview-1077--bitcoin-design-site.netlify.app/calendar/#transcripts)🫨