### PR TITLE
Add the Pix field study to the design research page

### DIFF
--- a/guide/resources/design-research.md
+++ b/guide/resources/design-research.md
@@ -97,6 +97,12 @@ A survey and follow-up interview of 990 bitcoin users to determine bitcoin manag
 
 ## Independent research
 
+#### [Pix in Brazil: A Field Study for the Bitcoin Community](https://www.psacramento.com/pix-in-brazil-a-field-study-for-the-bitcoin-community/)
+
+_2024 by Paulo Sacramento_
+
+A field study of the Brazilian payment system Pix, with a focus on learnings for the bitcoin community.
+
 #### [Rethinking Transaction Lists](https://blog.getalby.com/rethinking-transaction-lists/)
 
 _2022 by Alby._


### PR DESCRIPTION
Paulo shared [his research](https://www.psacramento.com/pix-in-brazil-a-field-study-for-the-bitcoin-community/) in Discord. I think it's a great addition to the design research page.

There might be some other spots in the guide we could link from that are more contextual. Maybe something for a separate PR.

🔎[Check the preview](https://deploy-preview-1080--bitcoin-design-site.netlify.app/guide/resources/design-research/#independent-research)🔍