### PR TITLE
Updated guide and case study index pages

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -172,19 +172,32 @@ Explanations of various technical aspects of bitcoin and lightning.
 [Automatic cloud backup]({{ '/guide/how-it-works/private-key-management/cloud-backup/' | relative_url }})<br />
 [Manual backup]({{ '/guide/how-it-works/private-key-management/manual-backup/' | relative_url }})<br />
 [External signers]({{ '/guide/how-it-works/private-key-management/external-signers/' | relative_url }})<br />
-[Multi-key]({{ '/guide/how-it-works/private-key-management/multi-key/' | relative_url }})
-
-</div>
-<div class="column" markdown="1">
-
+[Multi-key]({{ '/guide/how-it-works/private-key-management/multi-key/' | relative_url }})<br />
 [Bitcoin backups]({{ '/guide/how-it-works/backups/' | relative_url }})<br />
 [Payment request formats]({{ '/guide/how-it-works/payment-request-formats/' | relative_url }})<br />
 [Coin selection]({{ '/guide/how-it-works/coin-selection/' | relative_url }})<br />
 [Nodes]({{ '/guide/how-it-works/nodes/' | relative_url }})<br />
-[Transactions]({{ '/guide/how-it-works/transactions/' | relative_url }})
+
+</div>
+<div class="column" markdown="1">
+
+[Transactions]({{ '/guide/how-it-works/transactions/' | relative_url }})<br />
+[Wallet privacy]({{ '/guide/how-it-works/wallet-privacy/' | relative_url }})<br />
+[Wallet selector]({{ '/guide/how-it-works/wallet-selector/' | relative_url }})<br />
+[Custom spending conditions]({{ '/guide/how-it-works/custom-spending-conditions/' | relative_url }})<br />
+[Stabilizing bitcoin value]({{ '/guide/how-it-works/stabilizing-bitcoin-value/' | relative_url }})<br />
+[Lightning liquidity]({{ '/guide/how-it-works/liquidity/' | relative_url }})<br />
+[Lightning services]({{ '/guide/how-it-works/lightning-services/' | relative_url }})<br />
+[Sign in with bitcoin]({{ '/guide/how-it-works/sign-in-with-bitcoin/' | relative_url }})<br />
 
 </div>
 </div>
+
+---
+
+<h2 class="h3" markdown="1">[Case studies]({{ '/guide/case-studies/' | relative_url }})</h2>
+
+Collaboration summaries including [Blixt Wallet]({{ '/guide/case-studies/blixt-wallet/' | relative_url }}), [Payjoin]({{ '/guide/case-studies/payjoin/' | relative_url }}), [WalletScrutiny]({{ '/guide/case-studies/walletscrutiny/' | relative_url }}), and [Bitcoin Core App]({{ '/guide/case-studies/bitcoin-core-app/' | relative_url }}).
 
 ---
 

--- a/guide/case-studies/introduction.md
+++ b/guide/case-studies/introduction.md
@@ -38,6 +38,12 @@ This was a collaboration between WalletScrutiny and the Bitcoin Design Community
 
 ---
 
+### [Bitcoin Core App]({{ '/guide/case-studies/bitcoin-core-app' | relative_url }})
+
+An iniative to redesign the first bitcoin wallet ever.
+
+---
+
 {% include next-previous.html
    previousUrl = "/guide/how-it-works/stabilizing-bitcoin-value/"
    previousName = "Stabilizing bitcoin value"

--- a/guide/designing-products/units-and-symbols.md
+++ b/guide/designing-products/units-and-symbols.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Units & Symbols
+title: Units & symbols
 description: How to display and format bitcoin and currency units in bitcoin applications.
 nav_order: 7
 parent: Designing bitcoin products

--- a/guide/how-it-works/coin-selection.md
+++ b/guide/how-it-works/coin-selection.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Coin Selection
+title: Coin selection
 description: A primer on how UTXOs are chosen to fund new bitcoin transactions.
 nav_order: 2
 parent: How it works

--- a/guide/how-it-works/custom-spending-conditions.md
+++ b/guide/how-it-works/custom-spending-conditions.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Custom Spending Conditions
+title: Custom spending conditions
 description: An overview about advanced capabilities that enable users to create more flexible bitcoin wallets.
 nav_order: 12
 parent: How it works

--- a/guide/how-it-works/lightning-services.md
+++ b/guide/how-it-works/lightning-services.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Lightning Services
+title: Lightning services
 description: Third party services that solve common user experience problems when connecting to and using the lightning network.
 nav_order: 4
 parent: How it works


### PR DESCRIPTION
Those pages are essentially tables of content and were missing links to some sub-pages. Also included a handful of minor page title capitalization changes from title case to sentence case for consistency.

[Guide index page preview](https://deploy-preview-1089--bitcoin-design-site.netlify.app/guide/)
[Case studies intro page preview](https://deploy-preview-1089--bitcoin-design-site.netlify.app/guide/case-studies/)