### PR TITLE
Tweak to the CSS media query for retina screens

### DIFF
--- a/_sass/minima/_mixins.scss
+++ b/_sass/minima/_mixins.scss
@@ -82,8 +82,9 @@
 
 @mixin retina() {
   @media 
-    (-webkit-min-device-pixel-ratio: 2), 
-    (min-resolution: 192dpi) { 
+    screen and (-webkit-min-device-pixel-ratio: 1.5), 
+    screen and (min-resolution: 192dpi),
+    screen and (min-resolution: 2dppx) { 
       @content;
   }
 }


### PR DESCRIPTION
Abhijay007 pointed out that the header banner image is looking blurry on his mobile device in [this comment](https://github.com/BitcoinDesign/Guide/pull/1112#issuecomment-2324778040).

Reason is that our retina media query is looking for a pixel ratio of 2 for showing higher resolution images. Various Android phones are a little below 2 (like my Samsung Galaxy A5, which is ~1.875). For those phones, the lower res image looks blurry and the higher-res one would be more appropriate. This PR lowers the pixel ratio requirement from 2 to 1.5. This should work out better on average for diverse ratios.

Also added in the dppx unit, which is a newer standard.