### PR TITLE
Docker and image compression info tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ You can also run site locally with Docker.
 
 1. [Install docker](https://www.docker.com/products/docker-desktop)
 2. `cd` into a directory, for example `cd Documents/Guide`
-3. Run `docker-compose up` (you may need to wait for 5-10 minutes)
+3. Run `docker compose up` (you may need to wait for 5-10 minutes, use `docker-compose up` for older versions of Docker)

--- a/guide/contribute/illustration-guidelines.md
+++ b/guide/contribute/illustration-guidelines.md
@@ -154,7 +154,7 @@ Create and specify differently laid out images for desktop and mobile as needed.
 
 ## File size optimization
 
-Optimize your images before committing them. The easiest way is to [build and run this repository locally](https://github.com/BitcoinDesign/Guide#how-to-build-and-run-the-site-locally). Images will be automatically compressed as you add them. After compression, ensure that the quality is still acceptable. Heavily textured images are sometimes heavily compressed, resulting in visible compression crystals, blurry lines and other visual artefacts.
+Use PNG for images with mostly flat colors and JPG for more photographic images. Optimize your images before committing them. The easiest way is by using a tool like [ImageOptim]http://imageoptim.com). After compression, ensure that the quality is still acceptable. Heavily textured images are sometimes heavily compressed, resulting in visible compression crystals, blurry lines and other visual artefacts.
 
 ## Link preview images
 


### PR DESCRIPTION
Two minor maintenance copy tweaks:

- Newer version of Docker use "docker compose up" instead of "docker-compose up". This updates the info about local development in the README
- The local build does no longer automatically compress images, so I removed that part and added a note about using a compression tool like ImageOptim