### PR TITLE
Update community account Nostr relays

### DIFF
--- a/.well-known/nostr.json
+++ b/.well-known/nostr.json
@@ -4,18 +4,14 @@
   },
   "relays": {
     "8c29b321d0f3c61343882ea49623e84771690cd0566e40b90f08e5d34336aaa0": [
-      "wss://brb.io",
       "wss://eden.nostr.land",
       "wss://nos.lol",
       "wss://nostr-pub.wellorder.net",
       "wss://nostr.bitcoiner.social",
-      "wss://nostr.onsats.org",
-      "wss://nostr.orangepill.dev",
-      "wss://nostr.zebedee.cloud",
-      "wss://relay.current.fyi",
       "wss://relay.damus.io",
-      "wss://relay.nostr.info",
-      "wss://relay.snort.social"
+      "wss://relay.snort.social",
+      "wss://nostr.onsats.org",
+      "wss://nostr.land"
     ]
   }
 }


### PR DESCRIPTION
Several of the listed relays are no longer active. I tested all, compared to what Primal and Damus recommend as defaults, and adjusted the list