### PR TITLE
Add Umami tracking script

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,4 +18,6 @@
     };
   </script>
 
+  <script defer src="https://info.bitcoin.design/script.js" data-website-id="72eda115-bd02-4f52-83f8-284f441b702a" data-domains="bitcoin.design"></script>
+
 </head>

--- a/join.md
+++ b/join.md
@@ -293,5 +293,9 @@ This initiative was created to ensure the long-term sustainability of the effort
 
 For more information visit the [foundation website](https://opencollective.com/bitcoin-design-foundation). We are always thankful for donations and grant applications.
 
+## Tracking
+
+Please be aware that we currently use the analytics tool [Umami](https://umami.is/) to track activity on the site. This helps us better understand what content is useful in the guide. Umami is open-source and GDPR-compliant, and we host it ourselves. You can see the [public dashboard here](https://info.bitcoin.design/). More background on the decision to include tracking can be found [here](https://github.com/BitcoinDesign/Guide/issues/1125).
+
 </div>
 


### PR DESCRIPTION
As discussed in issue #1125, this adds the tracking script to our self-hosted instance of Umami. It is configured to only track on the bitcoin.design domain.