### PR TITLE
Minor link fixes to the Saving Satoshi PR

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -211,7 +211,7 @@ Explanations of various technical aspects of bitcoin and lightning.
 
 <h2 class="h3" markdown="1">[Case studies]({{ '/guide/case-studies/' | relative_url }})</h2>
 
-Collaboration summaries including [Blixt Wallet]({{ '/guide/case-studies/blixt-wallet/' | relative_url }}), [Payjoin]({{ '/guide/case-studies/payjoin/' | relative_url }}), [WalletScrutiny]({{ '/guide/case-studies/walletscrutiny/' | relative_url }}), and [Bitcoin Core App]({{ '/guide/case-studies/bitcoin-core-app/' | relative_url }}).
+Collaboration summaries including [Blixt Wallet]({{ '/guide/case-studies/blixt-wallet/' | relative_url }}), [Payjoin]({{ '/guide/case-studies/payjoin/' | relative_url }}), [WalletScrutiny]({{ '/guide/case-studies/walletscrutiny/' | relative_url }}), [Bitcoin Core App]({{ '/guide/case-studies/bitcoin-core-app/' | relative_url }}), and [Saving Satoshi]({{ '/guide/case-studies/saving-satoshi/' | relative_url }}).
 
 ---
 

--- a/guide/case-studies/bitcoin-core-app.md
+++ b/guide/case-studies/bitcoin-core-app.md
@@ -240,6 +240,6 @@ Next, view the [resources]({{ '/guide/resources' | relative_url }}) that can hel
 {% include next-previous.html
    previousUrl = "/guide/case-studies/walletscrutiny/"
    previousName = "WalletScrutiny"
-   nextUrl = "/guide/resources/"
-   nextName = "Resources"
+   nextUrl = "/guide/case-studies/saving-satoshi/"
+   nextName = "Saving Satoshi"
 %}

--- a/guide/case-studies/introduction.md
+++ b/guide/case-studies/introduction.md
@@ -46,7 +46,7 @@ An iniative to redesign the first bitcoin wallet ever.
 
 ### [Saving Satoshi]({{ '/guide/case-studies/saving-satoshi' | relative_url }})
 
-...
+An interactive game set that makes learning Bitcoin development engaging through storytelling and hands-on challenges. From mining to the Lightning Network, this unique educational project combines technical learning with narrative elements to onboard new bitcoin developers.
 
 ---
 

--- a/guide/case-studies/saving-satoshi.md
+++ b/guide/case-studies/saving-satoshi.md
@@ -444,8 +444,8 @@ A full list of code contributors can be found [on GitHub](https://github.com/sav
 Next, view the [resources]({{ '/guide/resources' | relative_url }}) that can help you build better bitcoin products.
 
 {% include next-previous.html
-   previousUrl = "/guide/case-studies/walletscrutiny/"
-   previousName = "WalletScrutiny"
-   nextUrl = "/guide/resources/"
-   nextName = "Resources"
+   previousUrl = "/guide/case-studies/bitcoin-core-app/"
+   previousName = "Bitcoin Core App"
+   nextUrl = "/guide/how-it-works/"
+   nextName = "How it works"
 %}

--- a/guide/how-it-works/introduction.md
+++ b/guide/how-it-works/introduction.md
@@ -111,8 +111,8 @@ An explainer for the different techniques for stabilizing bitcoin againts other 
 ---
 
 {% include next-previous.html
-   previousUrl = "/guide/multiple-wallets/"
-   previousName = "Multiple wallets"
+   previousUrl = "/guide/case-studies/saving-satoshi/"
+   previousName = "Saving Satoshi"
    nextUrl = "/guide/how-it-works/backups/"
    nextName = "Bitcoin backups"
 %}


### PR DESCRIPTION
Missed those in the main PR. Affects the next/previous buttons at the bottom of the page, and links from the guide and case studies section overview pages.