### PR TITLE
Silent Payments: add Wasabi Wallet sending support

### DIFF
--- a/guide/how-it-works/silent-payments.md
+++ b/guide/how-it-works/silent-payments.md
@@ -377,6 +377,7 @@ Applications should allow both backup & recovery through multiple methods. This 
 
 - [Cake wallet](https://cakewallet.com/)
 - [Blue wallet](https://bluewallet.io/) (sending only)
+- [Wasabi wallet](https://wasabiwallet.io/) (sending only)
 
 
 ---


### PR DESCRIPTION
Wasabi Wallet v2.4.0 brings send to Silent Payment addresses.

https://github.com/WalletWasabi/WalletWasabi/releases/tag/v2.4.0