### PR TITLE
Add underline to high contrast text when prefers-contrast is active

### DIFF
--- a/_sass/minima/_variables.scss
+++ b/_sass/minima/_variables.scss
@@ -61,8 +61,8 @@ $primary-color: $bitcoin-yellow;
     
     .guide a {
       text-decoration: underline;
-      text-decoration-thickness: 2px;
-      text-underline-offset: 2px;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 1px;
     }
   }
 }


### PR DESCRIPTION
Adds an underline to high contrast link text in the guide body when `prefers-contrast` is active as set by the user in their OS settings.

As per previous discussion: https://github.com/BitcoinDesign/Guide/pull/1015#issuecomment-1718882548

<img width="1462" alt="image" src="https://github.com/user-attachments/assets/89253c57-d1e5-4ba7-9b24-9ecf16c514fa" />
