### PR TITLE
Fix typos and improve text clarity in documentation

### DIFF
--- a/guide/contribute/propose-a-change.md
+++ b/guide/contribute/propose-a-change.md
@@ -211,7 +211,7 @@ These are the page properties at the top of markdown files, between the dividers
 - If a new page is a sub-section, make sure to include a reference in the section landing page ([example](https://bitcoin.design/guide/how-it-works/))
 - A simpler writing style allows your content to be more accessible to more readers (especially ones for whom english is not their native language)
 - For new pages, make sure to update the "Next" and "Previous" buttons on the respective next and previous pages
-- Look for opportunities to cross-reference other content in the guide. If somethig is already well-covered elsewhere, you can build on that
+- Look for opportunities to cross-reference other content in the guide. If something is already well-covered elsewhere, you can build on that
 
 **Images**
 - Ensure image content (especially text in images) is legible on mobile devices

--- a/guide/inheritance-wallet/onboarding-cosigners.md
+++ b/guide/inheritance-wallet/onboarding-cosigners.md
@@ -57,7 +57,7 @@ images_alice-enable-device:
       alt: Screen showing different options to export the wallet configuration.
       caption: Alice connects her BitBox via USB-C to export the wallet configuration.
     - file: alice-enable-device/enable-alice-device-flow
-      alt: Placholder screen representing the device-specific wallet activation flow.
+      alt: Placeholder screen representing the device-specific wallet activation flow.
       caption: The app guides her through the import flow on her BitBox.
     - file: alice-enable-device/enable-alice-success
       alt: Success screen showing the option activate another device or go to the home screen.

--- a/guide/resources/design-research.md
+++ b/guide/resources/design-research.md
@@ -252,7 +252,7 @@ Documentation of the user research, redesign and testing process of Coinhako, a 
 
 #### [Lightning Network UX Research](https://patestevao.com/work/lightning-network-ux-research/)
 
-The study conducted to look into the interactions between users and the lightning payments. It also reviewers three well-known projects at that time and looks through their user-experience.
+The study conducted to look into the interactions between users and the lightning payments. It also reviews three well-known projects at that time and looks through their user-experience.
 
 _2019 by Estevão._
 

--- a/guide/resources/design-research.md
+++ b/guide/resources/design-research.md
@@ -252,7 +252,7 @@ Documentation of the user research, redesign and testing process of Coinhako, a 
 
 #### [Lightning Network UX Research](https://patestevao.com/work/lightning-network-ux-research/)
 
-The study conducted to look into the interactions between users and the lightning payments. It also reviewes three well-known projects at that time and looks through their user-experience.
+The study conducted to look into the interactions between users and the lightning payments. It also reviewers three well-known projects at that time and looks through their user-experience.
 
 _2019 by Estevão._
 


### PR DESCRIPTION
This PR includes the following changes:

- Fix typo "somethig" -> "something" in propose-a-change.md
- Fix typo "Placholder" -> "Placeholder" in onboarding-cosigners.md 
- Fix grammar: "reviewes" -> "reviews" in design-research.md

These changes improve readability and correct minor text errors in the documentation.