### PR TITLE
Fix typos: "initiating" and "accommodate"

### DIFF
--- a/guide/how-it-works/private-key-management/multi-key.md
+++ b/guide/how-it-works/private-key-management/multi-key.md
@@ -121,7 +121,7 @@ Now Alice wants to send bitcoin received to the shared wallet. She can initiate 
    retina = "/assets/images/guide/how-it-works/private-key-management/multi-key/multi-key-diagram-1-signing@2x.png"
    mobile = "/assets/images/guide/how-it-works/private-key-management/multi-key/multi-key-diagram-1-signing-mobile.png"
    mobileRetina = "/assets/images/guide/how-it-works/private-key-management/multi-key/multi-key-diagram-1-signing-mobile@2x.png"
-   alt-text = "Diagram of Alice intiating a transaction and Robert signing it"
+   alt-text = "Diagram of Alice initiating a transaction and Robert signing it"
    width = 800
    height = 168
 %}

--- a/guide/multiple-wallets.md
+++ b/guide/multiple-wallets.md
@@ -291,7 +291,7 @@ However, we guide users towards using a single, primary private key to construct
 
 This simplifies the [backup process]({{ '/guide/how-it-works/backups/' | relative_url }}) to reduce the risk of loss of wallet. This is acceptable from a security perspective, because the wallets with larger amounts are either view-only (keys are external), or additionally protected by requiring multiple signatures (from the partner, hardware wallet, or assisted custody provider respectively).
 
-Remember to guide users during wallet setup towards best practices around [progressive security]({{ '/guide/getting-started/principles/#security' | relative_url }}). Even with strong guidance, you often still want to allow users to deviate, to accomodate their unique use case and context.
+Remember to guide users during wallet setup towards best practices around [progressive security]({{ '/guide/getting-started/principles/#security' | relative_url }}). Even with strong guidance, you often still want to allow users to deviate, to accommodate their unique use case and context.
 
 {% include image-gallery.html pages = page.images_custom_backup %}
 


### PR DESCRIPTION


**Changes made:**
- Corrected spelling of "initiating" in diagram alt text
- Fixed spelling of "accommodate" in security guidance text


