### PR TITLE
Typo fixes

### DIFF
--- a/guide/daily-spending-wallet/send-fees.md
+++ b/guide/daily-spending-wallet/send-fees.md
@@ -184,7 +184,7 @@ The most common scenario is that sender and receiver have an understanding of ho
 2. The sender balance is enough to cover the amount to pay, but not the fee
 3. The sender wants to clear out the wallet, possibly to migrate
 
-To accomodate these, the interface also needs to provide manual customization options, although they can be placed into secondary location (see below).
+To accommodate these, the interface also needs to provide manual customization options, although they can be placed into secondary location (see below).
 
 </div>
 

--- a/guide/inheritance-wallet/wallet-creation.md
+++ b/guide/inheritance-wallet/wallet-creation.md
@@ -165,7 +165,7 @@ images_david-send-key:
       caption: David receives the key request from his father in a text message.
     - file: wallet-creation/david-invite-loading-wallet
       alt: Screen showing a loading indicator.
-      caption: Our app opens an loads the wallet configuration. If David hadn't already installed the app, he would be taken to the app store to download it.
+      caption: Our app opens and loads the wallet configuration. If David hadn't already installed the app, he would be taken to the app store to download it.
     - file: wallet-creation/david-provide-wallet-overview
       alt: Screen displaying a visual representation of the wallet configuration.
       caption: The wallet overview screen shows that David's key will be part of the inheritance key set. 


### PR DESCRIPTION
Had Claude Code review all markdown files for typos. This is in response to getting a few automated PRs on the repo for fixing individual typos. Hopefully this fixes the remaining ones and we're good to go now.