### PR TITLE
Fix semantic markup of table of contents

### DIFF
--- a/guide/case-studies/payjoin.md
+++ b/guide/case-studies/payjoin.md
@@ -54,10 +54,10 @@ Illustration sources: <>
 {:.no_toc}
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/case-studies/saving-satoshi.md
+++ b/guide/case-studies/saving-satoshi.md
@@ -34,10 +34,10 @@ Illustration sources: <>
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/contribute/case-studies.md
+++ b/guide/contribute/case-studies.md
@@ -24,10 +24,10 @@ image: https://bitcoin.design/assets/images/guide/contribute/case-studies/case-s
 # Case study guidelines
 {:.no_toc}
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 There are various types of case studies. Some document proven solutions in the ecosystem, others are short, to the point stories of how a designer or team solved a particular challenge. This document is intended to help you write one of the latter. Ideally, a case study that is digestible for a wider audience, would be in the range of 1-4 pages in length.
 

--- a/guide/contribute/formatting/index.md
+++ b/guide/contribute/formatting/index.md
@@ -29,7 +29,7 @@ The design source file is a public Figma community file you can find [here](http
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 - [Text](#text-formatting)
 - [Headers](#headers)
 - [Blockquotes](#blockquote)
@@ -42,7 +42,7 @@ The design source file is a public Figma community file you can find [here](http
 - [Do's and don'ts](#dos-and-donts)
 - [Footnotes](#footnotes)
 - [Media]({{ '/guide/contribute/formatting/media/' | relative_url }})
-</div>
+</nav>
 
 ---
 

--- a/guide/contribute/formatting/media.md
+++ b/guide/contribute/formatting/media.md
@@ -34,10 +34,10 @@ videos:
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/contacts.md
+++ b/guide/daily-spending-wallet/contacts.md
@@ -209,10 +209,10 @@ Let's go over common user interactions around managing contacts. This will illus
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/first-use.md
+++ b/guide/daily-spending-wallet/first-use.md
@@ -84,10 +84,10 @@ https://www.figma.com/file/NjtMNQiJtoVkedEHgwD0A9/BTC-DSN-Guide-Header-Images?no
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/landing-page.md
+++ b/guide/daily-spending-wallet/landing-page.md
@@ -108,7 +108,7 @@ The daily spending wallet is an app designed to quickly and easily send small am
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
    <ul id="markdown-toc">
       <li><a href="/guide/daily-spending-wallet/first-use/">First use</a></li>
       <li><a href="/guide/daily-spending-wallet/backup-and-recovery/landing-page/">Backup & recovery</a></li>
@@ -120,7 +120,7 @@ The daily spending wallet is an app designed to quickly and easily send small am
       <li><a href="/guide/daily-spending-wallet/privacy/">Privacy</a></li>
       <li><a href="/guide/daily-spending-wallet/settings/">Settings</a></li>
    </ul>
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/privacy.md
+++ b/guide/daily-spending-wallet/privacy.md
@@ -37,10 +37,10 @@ https://www.figma.com/file/lf2Xyw2I2OXPsHiFQVQdiG/Daily-spending-wallet-prototyp
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/requesting/receiving.md
+++ b/guide/daily-spending-wallet/requesting/receiving.md
@@ -70,10 +70,10 @@ Once a user has shared a payment request, the next step is receiving the payment
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/requesting/requesting.md
+++ b/guide/daily-spending-wallet/requesting/requesting.md
@@ -128,10 +128,10 @@ Payment requests come in many different formats. Each has unique properties and 
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/security.md
+++ b/guide/daily-spending-wallet/security.md
@@ -105,10 +105,10 @@ https://www.figma.com/file/lf2Xyw2I2OXPsHiFQVQdiG/Daily-spending-wallet-prototyp
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/sending.md
+++ b/guide/daily-spending-wallet/sending.md
@@ -173,10 +173,10 @@ Sending bitcoin is one of the most essential user activities in a bitcoin applic
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/daily-spending-wallet/settings.md
+++ b/guide/daily-spending-wallet/settings.md
@@ -80,10 +80,10 @@ https://www.figma.com/file/lf2Xyw2I2OXPsHiFQVQdiG/Daily-spending-wallet-prototyp
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/designing-products/common-user-flows.md
+++ b/guide/designing-products/common-user-flows.md
@@ -47,10 +47,10 @@ Let's take a look at some common user needs and workflows that can be created fo
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/designing-products/personal-finance.md
+++ b/guide/designing-products/personal-finance.md
@@ -49,10 +49,10 @@ Assuming that a user wants to [self-custody](/guide/getting-started/principles/#
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/designing-products/user-personas.md
+++ b/guide/designing-products/user-personas.md
@@ -62,10 +62,10 @@ https://www.figma.com/community/file/1118899250147680107
 {:.no_toc}
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/getting-started/principles.md
+++ b/guide/getting-started/principles.md
@@ -40,7 +40,7 @@ These are principles we in the Bitcoin Design Community identified and stand beh
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 - [Self-custody](#self-custody)
 - [Security](#security)
 - [Inclusion](#inclusion)
@@ -48,7 +48,7 @@ These are principles we in the Bitcoin Design Community identified and stand beh
 - [Transparency](#transparency)
 - [Privacy](#privacy)
 - [Decentralization](#decentralization)
-</div>
+</nav>
 
 ---
 

--- a/guide/glossary/address.md
+++ b/guide/glossary/address.md
@@ -43,10 +43,10 @@ https://www.figma.com/file/qr4P17z6WSPADm6oW0cKw2/?node-id=25%3A2
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/glossary/index.md
+++ b/guide/glossary/index.md
@@ -33,10 +33,10 @@ https://www.figma.com/file/qzvCvqhSRx3Jq8aywaSjlr/Bitcoin-Design-Guide-Illustrat
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/how-it-works/ecash/design-best-practices.md
+++ b/guide/how-it-works/ecash/design-best-practices.md
@@ -319,10 +319,10 @@ Illustration sources: https://www.figma.com/community/file/1444347139219091325/b
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 ## Common ecash design guidelines

--- a/guide/how-it-works/human-readable-addresses.md
+++ b/guide/how-it-works/human-readable-addresses.md
@@ -67,10 +67,10 @@ https://www.figma.com/file/qzvCvqhSRx3Jq8aywaSjlr/Bitcoin-Design-Guide-Illustrat
 {:.no_toc}
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/how-it-works/liquidity.md
+++ b/guide/how-it-works/liquidity.md
@@ -34,10 +34,10 @@ Figma file for channel reserve UI's: https://www.figma.com/file/6iJpftEbajA3y1yl
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/how-it-works/sign-in-with-bitcoin.md
+++ b/guide/how-it-works/sign-in-with-bitcoin.md
@@ -35,10 +35,10 @@ and making payments on a web application via a lightning wallet.
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/how-it-works/silent-payments.md
+++ b/guide/how-it-works/silent-payments.md
@@ -101,10 +101,10 @@ https://www.figma.com/design/q8IYl9UVsOWkkPhs4IkHQR/Bitcoin-Wallet-UI-Kit-%26-De
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/how-it-works/stabilizing-bitcoin-value.md
+++ b/guide/how-it-works/stabilizing-bitcoin-value.md
@@ -33,10 +33,10 @@ https://www.figma.com/file/qzvCvqhSRx3Jq8aywaSjlr/Bitcoin-Design-Guide-Illustrat
 {:.no_toc}
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/how-it-works/wallet-privacy.md
+++ b/guide/how-it-works/wallet-privacy.md
@@ -31,10 +31,10 @@ This page provides a general overview of privacy issues in bitcoin wallets.
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/inheritance-wallet/backup.md
+++ b/guide/inheritance-wallet/backup.md
@@ -26,10 +26,10 @@ image_base: /assets/images/guide/inheritance-wallet/
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/inheritance-wallet/making-changes.md
+++ b/guide/inheritance-wallet/making-changes.md
@@ -192,10 +192,10 @@ images_config-changes:
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/inheritance-wallet/onboarding-cosigners.md
+++ b/guide/inheritance-wallet/onboarding-cosigners.md
@@ -94,10 +94,10 @@ https://www.figma.com/file/h5GP5v5dYfpXXfEUXf6nvC/Family-inheritance-wallet?type
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/inheritance-wallet/overview.md
+++ b/guide/inheritance-wallet/overview.md
@@ -35,10 +35,10 @@ https://www.figma.com/file/h5GP5v5dYfpXXfEUXf6nvC/Family-inheritance-wallet?type
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/inheritance-wallet/succession.md
+++ b/guide/inheritance-wallet/succession.md
@@ -109,10 +109,10 @@ images_inheritance-transaction-sign-david:
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/inheritance-wallet/wallet-creation.md
+++ b/guide/inheritance-wallet/wallet-creation.md
@@ -211,10 +211,10 @@ https://www.figma.com/file/h5GP5v5dYfpXXfEUXf6nvC/Family-inheritance-wallet?type
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 ## How it works

--- a/guide/multiple-wallets.md
+++ b/guide/multiple-wallets.md
@@ -128,10 +128,10 @@ Illustration sources
 {:.no_toc}
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 

--- a/guide/resources/design-research.md
+++ b/guide/resources/design-research.md
@@ -36,12 +36,12 @@ Below is a collection of published user research findings around bitcoin, from a
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
 - [Independent research](#independent-research)
 - [Journal Articles](#journal-articles)
 - [Case studies](#case-studies)
 - [Blog posts & write-ups](#blog-posts--write-ups)
-</div>
+</nav>
 
 ---
 

--- a/guide/savings-wallet/time-based-recovery.md
+++ b/guide/savings-wallet/time-based-recovery.md
@@ -205,10 +205,10 @@ https://www.figma.com/file/uxZMdWR2HfnKSMC9YWyr2h/Time-based-recovery?type=desig
 
 ---
 
-<div class="glossary-toc" markdown="1">
+<nav class="glossary-toc" markdown="1" aria-label="Table of contents">
  * Table of contents
 {:toc}
-</div>
+</nav>
 
 ---
 


### PR DESCRIPTION
Replacing the `div` used for table of content elements with `nav` tags ([info](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/nav)), as well as adding [aria-labels](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label). These two changes help screen readers and search engines correctly identify the elements as navigation and table of contents for the page.

Something that is not 100% ideal is that the automated table of contents creates unordered lists (`ul`). Ordered lists (`ol`) would be more appropriate, since the order of the table of contents always matches the order of the page content. But that is a built-in jekyll/markdown thing and can't be changed AFAICT.