### PR TITLE
Adds daily spending receive guidance for BOLT 12 and splicing

### DIFF
--- a/guide/daily-spending-wallet/requesting/requesting.md
+++ b/guide/daily-spending-wallet/requesting/requesting.md
@@ -159,7 +159,6 @@ This wallet defaults to a [unified payment request]({{ "/guide/how-it-works/paym
 
 Unified requests eliminate the hassle for users of choosing between requesting payment via the lightning network or on-chain. This choice can often be confusing, particularly for newcomers. 
 
-Got it — here’s a clean rewrite of your wallet guidance using **splicing** directly as the core mechanism:
 
 This wallet utilizes **splicing** for all on-chain transactions. Splicing allows the seamless transfer of received Bitcoin into the user's Lightning balance without maintaining a separate on-chain balance. As a result, the wallet presents a single Lightning balance, greatly simplifying the user experience. This approach is trust-minimized and non-custodial, as channel capacity can be increased or decreased directly on-chain without relying on external swap services. We cover these more in our \[lightning liquidity]\({{ "/guide/how-it-works/liquidity" | relative\_url }}) and receiving pages.
 

--- a/guide/daily-spending-wallet/requesting/requesting.md
+++ b/guide/daily-spending-wallet/requesting/requesting.md
@@ -155,13 +155,15 @@ Moreover, users have the option to skip entering an amount. This flexibility cat
 
 After entering an amount, the user taps the 'Request' button. The app then generates and presents a payment request.
 
-This wallet defaults to a [unified payment request]({{ "/guide/how-it-works/payment-request-formats/#unified-payment-requests" | relative_url }}). These combine a [lightning invoice]({{ "/guide/how-it-works/payment-request-formats/#invoice" | relative_url }}) and an [on-chain address]({{ "/guide/how-it-works/payment-request-formats/#addresses" | relative_url }}) into a single payment request using BIP21. 
+This wallet defaults to a [unified payment request]({{ "/guide/how-it-works/payment-request-formats/#unified-payment-requests" | relative_url }}). This combines a [lightning invoice]({{ "/guide/how-it-works/payment-request-formats/#invoice" | relative_url }}), an [offer]({{ "/guide/how-it-works/payment-request-formats/#offers" | relative_url }}) and an [on-chain address]({{ "/guide/how-it-works/payment-request-formats/#addresses" | relative_url }}) into a single payment request using BIP(3)21.
 
 Unified requests eliminate the hassle for users of choosing between requesting payment via the lightning network or on-chain. This choice can often be confusing, particularly for newcomers. 
 
-This wallet utilizes 'swap addresses' for all on-chain transactions. These are used to facilitate the transfer of received Bitcoin into the user's Lightning balance. Consequently, the wallet maintains a single Lightning balance, avoiding the need for a separate on-chain balance. This simplifies the user experience and is trust-minimized and non-custodial, courtesy of [submarine swaps](https://thebitcoinmanual.com/articles/btc-submarine-swaps/). We cover these more in our [lightning services]({{ "/guide/how-it-works/lightning-services/#swaps" | relative_url }}) and receiving pages.
+Got it — here’s a clean rewrite of your wallet guidance using **splicing** directly as the core mechanism:
 
-As unified requests [aren't widely supported yet](https://bitcoinqr.dev/), and users may want to request just from lightning or on-chain, they have options to share the lightning invoice or on-chain address independently. 
+This wallet utilizes **splicing** for all on-chain transactions. Splicing allows the seamless transfer of received Bitcoin into the user's Lightning balance without maintaining a separate on-chain balance. As a result, the wallet presents a single Lightning balance, greatly simplifying the user experience. This approach is trust-minimized and non-custodial, as channel capacity can be increased or decreased directly on-chain without relying on external swap services. We cover these more in our \[lightning liquidity]\({{ "/guide/how-it-works/liquidity" | relative\_url }}) and receiving pages.
+
+As unified requests [aren't widely supported yet](https://bitcoinqr.dev/), and users may want to request just from lightning or on-chain, they have options to share the lightning invoice/offer or on-chain address independently. 
 
 Receiving payments to this wallet requires users to be online. This wallet notifies users that their wallet should remain open until the payment is received. We cover this more on our [receiving]({{ "/guide/daily-spending-wallet/requesting/receiving/#receiving-offline" | relative_url }}) and [lighting services]({{ "/guide/how-it-works/lightning-services/#receive-payments-offline" | relative_url }}) pages.
 
@@ -223,7 +225,7 @@ Requests can be shared wirelessly over short distances using [near-field communi
 
 ### Payment link
 
-Payment links use a BIP21 [URI]({{ "/guide/how-it-works/payment-request-formats/#uniform-resource-identifier-uris-schemes" | relative_url }}) `bitcoin:` which makes these readable by other bitcoin applications. These can be included as part of a button or hyperlink. Also see the [wallet selector UI pattern]({{ "/guide/how-it-works/wallet-selector/" | relative_url }}).
+Payment links use a BIP(3)21 [URI]({{ "/guide/how-it-works/payment-request-formats/#uniform-resource-identifier-uris-schemes" | relative_url }}) `bitcoin:` which makes these readable by other bitcoin applications. These can be included as part of a button or hyperlink. Also see the [wallet selector UI pattern]({{ "/guide/how-it-works/wallet-selector/" | relative_url }}).
 
 {% include image-gallery.html pages = page.images_link %}
 

--- a/guide/daily-spending-wallet/requesting/requesting.md
+++ b/guide/daily-spending-wallet/requesting/requesting.md
@@ -162,7 +162,7 @@ Unified requests eliminate the hassle for users of choosing between requesting p
 
 This wallet utilizes **splicing** for all on-chain transactions. Splicing allows the seamless transfer of received Bitcoin into the user's Lightning balance without maintaining a separate on-chain balance. As a result, the wallet presents a single Lightning balance, greatly simplifying the user experience. This approach is trust-minimized and non-custodial, as channel capacity can be increased or decreased directly on-chain without relying on external swap services. We cover these more in our \[lightning liquidity]\({{ "/guide/how-it-works/liquidity" | relative\_url }}) and receiving pages.
 
-As unified requests [aren't widely supported yet](https://bitcoinqr.dev/), and users may want to request just from lightning or on-chain, they have options to share the lightning invoice/offer or on-chain address independently. 
+As unified requests [aren't widely supported yet](https://bitcoinqr.dev/), and users may want to request just from lightning or on-chain, they have options to share the lightning invoice or offer or on-chain address independently. 
 
 Receiving payments to this wallet requires users to be online. This wallet notifies users that their wallet should remain open until the payment is received. We cover this more on our [receiving]({{ "/guide/daily-spending-wallet/requesting/receiving/#receiving-offline" | relative_url }}) and [lighting services]({{ "/guide/how-it-works/lightning-services/#receive-payments-offline" | relative_url }}) pages.
 

--- a/guide/daily-spending-wallet/requesting/requesting.md
+++ b/guide/daily-spending-wallet/requesting/requesting.md
@@ -160,7 +160,7 @@ This wallet defaults to a [unified payment request]({{ "/guide/how-it-works/paym
 Unified requests eliminate the hassle for users of choosing between requesting payment via the lightning network or on-chain. This choice can often be confusing, particularly for newcomers. 
 
 
-This wallet utilizes **splicing** for all on-chain transactions. Splicing allows the seamless transfer of received Bitcoin into the user's Lightning balance without maintaining a separate on-chain balance. As a result, the wallet presents a single Lightning balance, greatly simplifying the user experience. This approach is trust-minimized and non-custodial, as channel capacity can be increased or decreased directly on-chain without relying on external swap services. We cover these more in our \[lightning liquidity]\({{ "/guide/how-it-works/liquidity" | relative\_url }}) and receiving pages.
+This wallet utilizes **splicing** for all on-chain transactions. Splicing allows the seamless transfer of received Bitcoin into the user's Lightning balance without maintaining a separate on-chain balance. As a result, the wallet presents a single Lightning balance, greatly simplifying the user experience. This approach is trust-minimized and non-custodial, as channel capacity can be increased or decreased directly on-chain without relying on external swap services. We cover these more in our [lightning liquidity]({{ "/guide/how-it-works/liquidity" | relative_url }}) and receiving pages.
 
 As unified requests [aren't widely supported yet](https://bitcoinqr.dev/), and users may want to request just from lightning or on-chain, they have options to share the lightning invoice or offer or on-chain address independently. 
 


### PR DESCRIPTION
I've added a recommendation to also include BOLT 12 in the default BIP(3)21 URI. We are now at a stage where prominent bitcoin wallets are supporting it as evidenced at [bolt12.org](https://bolt12.org/). It will also be supported soon in bLIP-52/LSPS2 for inbound liquidity.

The mockups should include the ability to generate a QR code with a BOLT 12 offer.

Splicing also offers significant advantages for managing Lightning Network channels, making the user experience more fluid and cost-effective. It doesn't require a third party to help facilitate the swap. Phoenix wallet offer this functionality by default.