### PR TITLE
Hide Next button when only one banner theme is active

### DIFF
--- a/js/themes.js
+++ b/js/themes.js
@@ -585,11 +585,15 @@ docReady(function() {
 
         var bannerNext = document.getElementById('home-banner-info-next');
         if(bannerNext) {
-            bannerNext.addEventListener('click', function(event) {
-                event.preventDefault();
+            if(themes.length <= 1) {
+                bannerNext.style.display = 'none';
+            } else {
+                bannerNext.addEventListener('click', function(event) {
+                    event.preventDefault();
 
-                applyNextTheme();
-            });
+                    applyNextTheme();
+                });
+            }
         }
     }
 });


### PR DESCRIPTION
## Summary

- The homepage banner theme carousel (`js/themes.js`) currently has all but one theme commented out for Impact Initiatives 2026
- With a single active theme, the **Next** button cycles through a one-element array — clicking it does nothing
- This hides the Next button when `themes.length <= 1`, while keeping the **Submit your own** link visible
- When themes are re-enabled, the Next button automatically reappears

## Test plan

- [ ] Load the homepage — verify "Submit your own" is visible and "Next" is hidden
- [ ] Uncomment one additional theme in `js/themes.js` — verify both "Submit your own" and "Next" appear and Next cycles themes