### PR TITLE
Make full-width images span the entire viewport on non-sidebar pages

### DIFF
--- a/_sass/minima/_article.scss
+++ b/_sass/minima/_article.scss
@@ -362,7 +362,9 @@ article.guide {
     }
   }
 
-  // Full width images stretch all the way, up to 1600px width.
+  // Full width images stretch all the way.
+  // On non-sidebar pages, break out to full viewport width.
+  // On sidebar pages, only cancel the article padding.
 
   & > .-full-width {
     display: flex;
@@ -381,6 +383,30 @@ article.guide {
     @include media-query(large) {
       margin-left: - $spacing-unit;
       margin-right: - $spacing-unit;
+    }
+  }
+
+  .main:not(.sidebar) > & > .-full-width {
+    @include media-query(large) {
+      width: 100vw;
+      margin-left: calc(-50vw + 50%);
+      margin-right: calc(-50vw + 50%);
+
+      figure {
+        width: 100%;
+      }
+
+      picture {
+        display: block;
+        width: 100%;
+      }
+
+      img {
+        width: 100%;
+        max-width: none;
+        max-height: calc(#{$content-width - $spacing-unit * 4} * 0.375); // 600:1600 banner ratio
+        object-fit: cover;
+      }
     }
   }
 

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -32,6 +32,7 @@ body {
   min-height: 100vh;
   flex-direction: column;
   overflow-wrap: break-word;
+  overflow-x: hidden;
   width: 100%;
   box-sizing:border-box;
 }


### PR DESCRIPTION
## Summary

- On pages without a sidebar (social-media, newsletter, calendar, join, projects, community, collabs), full-width images were constrained to the `.main` container's `max-width: 1280px`, leaving gaps on both sides
- This breaks `.-full-width` elements out to the full viewport width using `width: 100vw` and `calc(-50vw + 50%)` margins
- Images maintain a consistent height via `max-height` with `object-fit: cover` for natural cropping
- Adds `overflow-x: hidden` on body to prevent horizontal scrollbar from the `100vw` technique
- Sidebar guide pages are completely unaffected — they keep existing behavior

**Pages affected:** `/social-media/`, `/newsletter/`, `/calendar/`, `/join/`, `/projects/`, `/community/`, `/collabs/`

## Test plan

- [ ] Check each affected page above at desktop width — images should span edge-to-edge
- [ ] Check at tablet/mobile — no change from current behavior (existing negative margins handle it)
- [ ] Check a guide page with sidebar (e.g. `/guide/glossary/address/`) — should be unchanged
- [ ] Verify no horizontal scrollbar appears on any page
- [ ] Verify figcaptions (e.g. "Illustration via Control" on `/calendar/`) are still visible below images